### PR TITLE
Fixed an issue with resetting letters on the map

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1176,6 +1176,8 @@ function resetPage() {
     $("#panels-randomized").click();
     $("#coins-randomized").click();
     $("#coins-randomized").click();
+    $("#letters-randomized").click();
+    $("#letters-randomized").click();
 }
 
 function savePageState() {


### PR DESCRIPTION
If letter randomization is off, when the tracker was reset, areas whose only checks are letters (Nomadimouse room in Dry Dry Desert and Shop in Boo's Mansion) were not crossed out on the tracker. This change should fix that issue.