### PR TITLE
Add Koopa Koot to map tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,8 @@
                                     <td data-checks-list="maps-toad-town-summit">Shooting Star Summit</td>
                                 </tr>
                                 <tr>
-                                    <td class="empty" colspan="2"/>
+                                    <td class="empty" colspan=""/>
+                                    <td data-checks-list="maps-toad-town-mario-house">Mario's House</td>
                                     <td data-checks-list="maps-toad-town-merluvlee">Merluvlee's House</td>
                                 </tr>
                                 <tr>
@@ -943,6 +944,7 @@
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompa</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompapa 1 (Chain)</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompapa 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Koot] Talk to Goompa after Koopa Koot asks for his Tape</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Give Dolly to Goombaria</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goombario</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goompa</label></li>
@@ -995,11 +997,18 @@
                                 <li><label><input data-map-group="maps-toad-town-castle" autocomplete="off" type="checkbox">[Panel] Right side of bridge</label></li>
                             </ul>
                         </div>
+                        <div id="maps-toad-town-mario-house" style="display:none;">
+                            <h3>Mario's House</h3>
+                            <ul>
+                                <li><label><input data-map-group="maps-toad-town-mario-house" autocomplete="off" type="checkbox">[Koot] Talk to Luigi after Koopa Koot requests his autograph</label></li>
+                            </ul>
+                        </div>
                         <div id="maps-toad-town-merluvlee" style="display:none;">
                             <h3>Merluvlee's House</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Panel] In front of pot outside house</label></li>
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Letter] Merlow</label></li>
+                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Koot] Give Merluvlee the Crystal Ball</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-harbor" style="display:none;">
@@ -1208,6 +1217,8 @@
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Mort T.</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Koover 1 (Chain)</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Koover 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Koot] Far right bush after Koopa Koot requests his Wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Koot] Second bush from left after Koopa Koot requests his Glasses</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Bottom bush on left side</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Third bush from the right</label></li>
                             </ul>
@@ -1216,6 +1227,29 @@
                             <h3>Koopa Village East</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Letter] Kolorado</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Kolorado's wife after starting Koopa Koot's first favor</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Legends to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Sleepy Sheep (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Sleepy Sheep (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's Tape</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot Koopa Tea</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Luigi's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Tasty Tonic</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Merluvlee's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Talk to Koopa Koot after reading the news in Toad Town</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Life Shroom (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Life Shroom (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Nutty Cake</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Koopa Koot after calming the Bob-ombs</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot the Old Photo</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot Koopasta</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's glasses</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Lime</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Kooky Cookie</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot his package</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Coconut</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot the Red Jar</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">First bush on left</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Give Kooper his shell</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Give Artifact to Kolorado</label></li>
@@ -1403,6 +1437,7 @@
                             <h3>Dry Dry Outpost West</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">[Letter] Shop (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">[Koot] Buy Dusty Hammer, Dried Pasta, Dusty Hammer, Dried Shroom after Koopa Koot requests Red Red Jar</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">Turn in Lyrics at far right house</label></li>
                             </ul>
                         </div>
@@ -1411,6 +1446,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Panel] On rooftops</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Letter] Mr. E (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Koot] Talk to Merlee after Merluvlee requests Crystal Ball</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">Item on rooftops</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">Talk to Moustafa after buying Dried Shroom + Dusty Hammer</label></li>
                             </ul>
@@ -1565,6 +1601,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Panel] By couch</label></li>
                                 <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Letter] Franky (Chain)</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Koot] Talk to Franky after Koopa Koot requests the Old Photo</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-record" style="display:none;">
@@ -1633,6 +1670,7 @@
                             <h3>Village 1</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox">[Coinsanity] Block in far right house</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox">[Koot] Talk to Boo near Save Block after Koopa Koot requests a Package</label></li>
                             </ul>
                         </div>
                         <div id="maps-gusty-gulch-1" style="display:none;">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -767,6 +767,9 @@ $(document).ready(function(){
         var isChecked = $(this).is(':checked');
         $(".koopa-koot-generated-item").toggle(isChecked);
         $(".koopa-koot-tracker").toggle(isChecked);
+        toggleChecks("[Koot]", !isChecked);
+        toggleChecks("[Koot] [Coinsanity]", !isChecked || !$("#coins-randomized").is(':checked'));
+        countChecks();
         localStorage.setItem("koopa-koot-randomized", isChecked);
         $("#flag-koopakoot").toggle(isChecked);
     });
@@ -1001,6 +1004,7 @@ $(document).ready(function(){
         var isChecked = $(this).is(':checked');
         localStorage.setItem("coins-randomized", isChecked);
         toggleChecks("[Coinsanity]", !isChecked);
+        toggleChecks("[Koot] [Coinsanity]", !isChecked || !$("#koopa-koot-randomized").is(':checked'));
         $("#flag-coinsanity").toggle(isChecked);
         countChecks();
     });
@@ -1178,6 +1182,8 @@ function resetPage() {
     $("#coins-randomized").click();
     $("#letters-randomized").click();
     $("#letters-randomized").click();
+    $("#koopa-koot-randomized").click();
+    $("#koopa-koot-randomized").click();
 }
 
 function savePageState() {

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -16,7 +16,7 @@ function countChecks() {
 
     $("#map-checks label").each(function() {
         if ($(this).text().includes("[Coinsanity]")) {
-            if ($("#coins-randomized").is(':checked')) {
+            if ($("#coins-randomized").is(':checked') && !$(this).hasClass('disabled')) {
                 ++coinsanity_checks;
                 ++total_checks;
             }
@@ -27,6 +27,10 @@ function countChecks() {
             }
         } else if ($(this).text().includes("[Dojo]")) {
             if ($("#dojo-randomized").is(':checked')) {
+                ++total_checks;
+            }
+        } else if ($(this).text().includes("[Koot]")) {
+            if ($("#koopa-koot-randomized").is(':checked') && !$(this).hasClass('disabled')) {
                 ++total_checks;
             }
         } else if ($(this).text().includes("[Letter]")) {


### PR DESCRIPTION
All Koopa Koot-related checks now appear on the map tracker. Checks that are only randomized with Coinsanity enabled are marked as such. Resolves issue #40