### PR TITLE
Display map checks based on completability

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,8 @@
                                     <td data-checks-list="maps-toad-town-summit">Shooting Star Summit</td>
                                 </tr>
                                 <tr>
-                                    <td class="empty" colspan="2"/>
+                                    <td class="empty" colspan=""/>
+                                    <td data-checks-list="maps-toad-town-mario-house">Mario's House</td>
                                     <td data-checks-list="maps-toad-town-merluvlee">Merluvlee's House</td>
                                 </tr>
                                 <tr>
@@ -943,6 +944,7 @@
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompa</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompapa 1 (Chain)</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompapa 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Koot] Talk to Goompa after Koopa Koot asks for his Tape</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Give Dolly to Goombaria</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goombario</label></li>
                                 <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goompa</label></li>
@@ -995,11 +997,18 @@
                                 <li><label><input data-map-group="maps-toad-town-castle" autocomplete="off" type="checkbox">[Panel] Right side of bridge</label></li>
                             </ul>
                         </div>
+                        <div id="maps-toad-town-mario-house" style="display:none;">
+                            <h3>Mario's House</h3>
+                            <ul>
+                                <li><label><input data-map-group="maps-toad-town-mario-house" autocomplete="off" type="checkbox">[Koot] Talk to Luigi after Koopa Koot requests his autograph</label></li>
+                            </ul>
+                        </div>
                         <div id="maps-toad-town-merluvlee" style="display:none;">
                             <h3>Merluvlee's House</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Panel] In front of pot outside house</label></li>
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Letter] Merlow</label></li>
+                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Koot] Give Merluvlee the Crystal Ball</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-harbor" style="display:none;">
@@ -1208,6 +1217,8 @@
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Mort T.</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Koover 1 (Chain)</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Koover 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Koot] Far right bush after Koopa Koot requests his Wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Koot] Second bush from left after Koopa Koot requests his Glasses</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Bottom bush on left side</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Third bush from the right</label></li>
                             </ul>
@@ -1216,6 +1227,29 @@
                             <h3>Koopa Village East</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Letter] Kolorado</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Kolorado's wife after starting Koopa Koot's first favor</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Legends to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Sleepy Sheep (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Sleepy Sheep (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's Tape</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot Koopa Tea</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Luigi's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Tasty Tonic</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Merluvlee's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Talk to Koopa Koot after reading the news in Toad Town</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Life Shroom (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Life Shroom (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Nutty Cake</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Koopa Koot after calming the Bob-ombs</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot the Old Photo</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot Koopasta</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's glasses</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Lime</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Kooky Cookie</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot his package</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Coconut</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot the Red Jar</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">First bush on left</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Give Kooper his shell</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Give Artifact to Kolorado</label></li>
@@ -1403,6 +1437,7 @@
                             <h3>Dry Dry Outpost West</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">[Letter] Shop (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">[Koot] Buy Dusty Hammer, Dried Pasta, Dusty Hammer, Dried Shroom after Koopa Koot requests Red Red Jar</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">Turn in Lyrics at far right house</label></li>
                             </ul>
                         </div>
@@ -1411,6 +1446,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Panel] On rooftops</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Letter] Mr. E (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Koot] Talk to Merlee after Merluvlee requests Crystal Ball</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">Item on rooftops</label></li>
                                 <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">Talk to Moustafa after buying Dried Shroom + Dusty Hammer</label></li>
                             </ul>
@@ -1565,6 +1601,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Panel] By couch</label></li>
                                 <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Letter] Franky (Chain)</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Koot] Talk to Franky after Koopa Koot requests the Old Photo</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-record" style="display:none;">
@@ -1633,6 +1670,7 @@
                             <h3>Village 1</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox">[Coinsanity] Block in far right house</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox">[Koot] Talk to Boo near Save Block after Koopa Koot requests a Package</label></li>
                             </ul>
                         </div>
                         <div id="maps-gusty-gulch-1" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -1977,7 +1977,7 @@
                         <div id="maps-yoshi-west-village" style="display:none;">
                             <h3>West Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Panel] In front of raven statue</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of raven statue</label></li>
                                 <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie'">Talk to Yoshi Chief after saving all the kids</label></li>
                                 <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Left Coconut tree</label></li>
                                 <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Right Coconut tree</label></li>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
         <meta name="author" content="Phantom Games LLC.">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
         <script src="scripts/compact.js?version=14"></script>
-        <script src="scripts/maps.js?version=8"></script>
-        <script src="scripts/main.js?version=23"></script>
+        <script src="scripts/maps.js?version=9"></script>
+        <script src="scripts/main.js?version=24"></script>
         <link rel="stylesheet" href="styles/main.css?version=15">
 
         <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -918,65 +918,65 @@
                         <div id="maps-prologue-playground" style="display:none;">
                             <h3>Playground</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-playground" autocomplete="off" type="checkbox">Far right tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Far right tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-outside-playground" style="display:none;">
                             <h3>Outside Playground</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox">[Panel] Right of stone block</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox">[Coinsanity] 4 items above spring</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox">[Coinsanity] Far left ? Block</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox">Tree</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox">Item on ledge above spring</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox">? Block above stone block</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right of stone block</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] 4 items above spring</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Far left ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Item on ledge above spring</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">? Block above stone block</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-outside-village" style="display:none;">
                             <h3>Outside Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-outside-village" autocomplete="off" type="checkbox">Item on ledge</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Item on ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-village" style="display:none;">
                             <h3>Goomba Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompa</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompapa 1 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Letter] Goompapa 2 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">[Koot] Talk to Goompa after Koopa Koot asks for his Tape</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Give Dolly to Goombaria</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goombario</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goompa</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Goompa's Veranda</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox">Tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Goompa'">[Letter] Goompa</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Goompapa 1'">[Letter] Goompapa 1 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Goompapa 2'">[Letter] Goompapa 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep'">[Koot] Talk to Goompa after Koopa Koot asks for his Tape</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Dolly'">Give Dolly to Goombaria</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Goombario</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Goompa</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Goompa's Veranda</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-landing" style="display:none;">
                             <h3>Mario's Landing</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-landing" autocomplete="off" type="checkbox">[Panel] Middle of the room</label></li>
+                                <li><label><input data-map-group="maps-prologue-landing" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of the room</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-road1" style="display:none;">
                             <h3>Goomba Road 1</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-road2" style="display:none;">
                             <h3>Goomba Road 2</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox">? Block</label></li>
-                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox">Sign</label></li>
+                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Sign</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-castle" style="display:none;">
                             <h3>Goomba King's Castle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox">[Panel] Right side of Goomba King's Fortress near tree</label></li>
-                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox">Tree left of the fortress</label></li>
+                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right side of Goomba King's Fortress near tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Tree left of the fortress</label></li>
                                 <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox">Break brick block to spawn ? Block</label></li>
                             </ul>
                         </div>
@@ -986,38 +986,38 @@
                         <div id="maps-toad-town-summit" style="display:none;">
                             <h3>Shooting Star Summit</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-summit" autocomplete="off" type="checkbox">[Panel] On First Step</label></li>
+                                <li><label><input data-map-group="maps-toad-town-summit" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] On First Step</label></li>
                                 <li><label><input data-map-group="maps-toad-town-summit" autocomplete="off" type="checkbox">Left from entrance</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-castle" style="display:none;">
                             <h3>Castle Ruins</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-castle" autocomplete="off" type="checkbox">[Letter] Muss T. (Chain)</label></li>
-                                <li><label><input data-map-group="maps-toad-town-castle" autocomplete="off" type="checkbox">[Panel] Right side of bridge</label></li>
+                                <li><label><input data-map-group="maps-toad-town-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="'Muss T. (Castle Ruins)'">[Letter] Muss T. (Chain)</label></li>
+                                <li><label><input data-map-group="maps-toad-town-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right side of bridge</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-mario-house" style="display:none;">
                             <h3>Mario's House</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-mario-house" autocomplete="off" type="checkbox">[Koot] Talk to Luigi after Koopa Koot requests his autograph</label></li>
+                                <li><label><input data-map-group="maps-toad-town-mario-house" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea'">[Koot] Talk to Luigi after Koopa Koot requests his autograph</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-merluvlee" style="display:none;">
                             <h3>Merluvlee's House</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Panel] In front of pot outside house</label></li>
-                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Letter] Merlow</label></li>
-                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Koot] Give Merluvlee the Crystal Ball</label></li>
+                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of pot outside house</label></li>
+                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="'Merlow'">[Letter] Merlow</label></li>
+                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Crystal Ball'">[Koot] Give Merluvlee the Crystal Ball</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-harbor" style="display:none;">
                             <h3>Toad Town Harbor</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox">[Panel] Outside Club 64</label></li>
-                                <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox">[Letter] Fishmael (Chain)</label></li>
+                                <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Outside Club 64</label></li>
+                                <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" data-requirements-glitchless="'Fishmael'">[Letter] Fishmael (Chain)</label></li>
                                 <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox">Talk to Simon in Club 64 (first time)</label></li>
-                                <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox">Give Melody to Simon in Club 64</label></li>
+                                <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" data-requirements-glitchless="'Melody'">Give Melody to Simon in Club 64</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-outside" style="display:none;">
@@ -1030,51 +1030,51 @@
                         <div id="maps-toad-town-gate" style="display:none;">
                             <h3>Main Gate</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox">[Panel] By three toad sisters</label></li>
-                                <li><label class="disabled"><input data-sync="Chan" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled>[Dojo] Defeat Chan (logic from beginng)</label></li>
-                                <li><label class="disabled"><input data-sync="Lee" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled>[Dojo] Defeat Lee (logic after 2 star spirits)</label></li>
-                                <li><label class="disabled"><input id="master-1-maps" data-map-group="maps-toad-town-gate" data-key-sync="Master=1" autocomplete="off" type="checkbox" disabled>[Dojo] Defeat Master 1 (logic after 3 star spirits)</label></li>
-                                <li><label class="disabled"><input id="master-2-maps" data-key-sync="Master=2" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled>[Dojo] Defeat Master 2 (logic after 4 star spirits)</label></li>
-                                <li><label class="disabled"><input id="master-3-maps" data-key-sync="Master=3" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled>[Dojo] Defeat Master 3 (logic after 5 star spirits)</label></li>
-                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox">[Letter] Miss T.</label></li>
-                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox">[Letter] Russ T.</label></li>
-                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox">Give Dictionary to Russ T.</label></li>
-                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox">Item at Sushie panel</label></li>
+                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By three toad sisters</label></li>
+                                <li><label class="disabled"><input data-sync="Chan" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled>[Dojo] Defeat Chan (logic from beginning)</label></li>
+                                <li><label class="disabled"><input data-sync="Lee" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="2">[Dojo] Defeat Lee (logic after 2 star spirits)</label></li>
+                                <li><label class="disabled"><input id="master-1-maps" data-map-group="maps-toad-town-gate" data-key-sync="Master=1" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="3">[Dojo] Defeat Master 1 (logic after 3 star spirits)</label></li>
+                                <li><label class="disabled"><input id="master-2-maps" data-key-sync="Master=2" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="4">[Dojo] Defeat Master 2 (logic after 4 star spirits)</label></li>
+                                <li><label class="disabled"><input id="master-3-maps" data-key-sync="Master=3" data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="5">[Dojo] Defeat Master 3 (logic after 5 star spirits)</label></li>
+                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Miss T.'">[Letter] Miss T.</label></li>
+                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Russ T.'">[Letter] Russ T.</label></li>
+                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Dictionary'">Give Dictionary to Russ T.</label></li>
+                                <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Sushie'">Item at Sushie panel</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-center" style="display:none;">
                             <h3>Central Plaza</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">[Letter] Merlon</label></li>
-                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">[Letter] Minh T. (Chain)</label></li>
+                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Merlon'">[Letter] Merlon</label></li>
+                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Minh T.'">[Letter] Minh T. (Chain)</label></li>
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">Tree by Merlon's house</label></li>
-                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">Give Calculator to Rowf</label></li>
-                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">Give Mailbag to Post Office</label></li>
-                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">Ground Pound inside Merlon's house 3 times</label></li>
+                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Calculator'">Give Calculator to Rowf</label></li>
+                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Mailbag'">Give Mailbag to Post Office</label></li>
+                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots']">Ground Pound inside Merlon's house 3 times</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-below-center" style="display:none;">
                             <h3>Below Plaza</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox">[Panel] By guard house</label></li>
-                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox">[Letter] Fice T.</label></li>
+                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By guard house</label></li>
+                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Fice T.'">[Letter] Fice T.</label></li>
                                 <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox">Bub-ulb</label></li>
-                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox">Give Frying Pan to Tayce T.</label></li>
-                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox">Inside Blue House</label></li>
+                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Frying Pan'">Give Frying Pan to Tayce T.</label></li>
+                                <li><label><input data-map-group="maps-toad-town-below-center" autocomplete="off" type="checkbox" data-requirements-glitchless="['Odd Key','blue-house-open',['Super Boots','Sushie','Bombette'],['Ultra Boots','Sushie','Bombette']]">Inside Blue House</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-residential" style="display:none;">
                             <h3>Residential Area</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-residential" autocomplete="off" type="checkbox">Four items in Harry's Storeroom</label></li>
+                                <li><label><input data-map-group="maps-toad-town-residential" autocomplete="off" type="checkbox" data-requirements-glitchless="'Storeroom Key'">Four items in Harry's Storeroom</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-train" style="display:none;">
                             <h3>Train Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-train" autocomplete="off" type="checkbox">[Panel] Bottom right side of room</label></li>
-                                <li><label><input data-map-group="maps-toad-town-train" autocomplete="off" type="checkbox">[Letter] Dane T. 1 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-toad-town-train" autocomplete="off" type="checkbox">[Letter] Dane T. 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-toad-town-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Bottom right side of room</label></li>
+                                <li><label><input data-map-group="maps-toad-town-train" autocomplete="off" type="checkbox" data-requirements-glitchless="'Dane T. 1'">[Letter] Dane T. 1 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-toad-town-train" autocomplete="off" type="checkbox" data-requirements-glitchless="'Dane T. 2'">[Letter] Dane T. 2 (Chain)</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1083,9 +1083,9 @@
                         <div id="maps-sewers-pipe" style="display:none;">
                             <h3>Pipe</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-pipe" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-sewers-pipe" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-sewers-pipe" autocomplete="off" type="checkbox">Middle ? Block</label></li>
+                                <li><label><input data-map-group="maps-sewers-pipe" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-sewers-pipe" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-sewers-pipe" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Middle ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-bricks" style="display:none;">
@@ -1103,54 +1103,54 @@
                         <div id="maps-sewers-upgrade" style="display:none;">
                             <h3>Upgrade Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-upgrade" autocomplete="off" type="checkbox">[Coinsanity] Left invisible block</label></li>
-                                <li><label><input data-map-group="maps-sewers-upgrade" autocomplete="off" type="checkbox">[Coinsanity] Middle invisible block</label></li>
-                                <li><label><input data-map-group="maps-sewers-upgrade" autocomplete="off" type="checkbox">[Coinsanity] Right invisible block</label></li>
+                                <li><label><input data-map-group="maps-sewers-upgrade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots',['Odd Key','Bombette','Sushie'],['blue-house-open','Bombette','Sushie']]">[Coinsanity] Left invisible block</label></li>
+                                <li><label><input data-map-group="maps-sewers-upgrade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots',['Odd Key','Bombette','Sushie'],['blue-house-open','Bombette','Sushie']]">[Coinsanity] Middle invisible block</label></li>
+                                <li><label><input data-map-group="maps-sewers-upgrade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots',['Odd Key','Bombette','Sushie'],['blue-house-open','Bombette','Sushie']]">[Coinsanity] Right invisible block</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-spike-room" style="display:none;">
                             <h3>Spike Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-spike-room" autocomplete="off" type="checkbox">Ultra Boots ? block</label></li>
+                                <li><label><input data-map-group="maps-sewers-spike-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Ultra Boots',[['Odd Key','Bombette'],['blue-house-open','Bombette'],'Sushie']">Ultra Boots ? block</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-chapter-7" style="display:none;">
                             <h3>Chapter 7 Door</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox">[Coinsanity] ? Block 1</label></li>
-                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox">[Coinsanity] ? Block 2</label></li>
-                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox">[Coinsanity] ? Block 3</label></li>
-                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox">[Coinsanity] ? Block 4</label></li>
-                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox">[Coinsanity] ? Block 5</label></li>
+                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] ? Block 1</label></li>
+                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] ? Block 2</label></li>
+                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] ? Block 3</label></li>
+                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] ? Block 4</label></li>
+                                <li><label><input data-map-group="maps-sewers-chapter-7" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] ? Block 5</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-power-smash" style="display:none;">
                             <h3>Power Smash</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-power-smash" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-sewers-power-smash" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-power-elevator" style="display:none;">
                             <h3>Elevator</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-power-elevator" autocomplete="off" type="checkbox">Item on far right ledge</label></li>
+                                <li><label><input data-map-group="maps-sewers-power-elevator" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Parakarry'">Item on far right ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-life-shroom" style="display:none;">
                             <h3>Ultra Boots Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-life-shroom" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-sewers-life-shroom" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-sewers-life-shroom" autocomplete="off" type="checkbox">Middle ? Block</label></li>
+                                <li><label><input data-map-group="maps-sewers-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="'Ultra Boots',[['Odd Key','Bombette'],['blue-house-open','Bombette'],'Sushie'],'Lakilester'">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-sewers-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="'Ultra Boots',[['Odd Key','Bombette'],['blue-house-open','Bombette'],'Sushie'],'Lakilester'">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-sewers-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="'Ultra Boots',[['Odd Key','Bombette'],['blue-house-open','Bombette'],'Sushie'],'Lakilester'">Middle ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-spiny" style="display:none;">
                             <h3>Spiny Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox">Invisible block left of pipe</label></li>
-                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox">Invisible block between first and second spiny</label></li>
-                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox">Invisible block next to visible ? block</label></li>
-                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox">[Coinsanity] ? Block by stone block</label></li>
+                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Odd Key','Bombette'],['blue-house-open','Bombette'],['Super Boots','Sushie'],['Ultra Boots','Sushie']],'Lakilester'">Invisible block left of pipe</label></li>
+                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Odd Key','Bombette'],['blue-house-open','Bombette'],['Super Boots','Sushie'],['Ultra Boots','Sushie']],'Lakilester'">Invisible block between first and second spiny</label></li>
+                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Odd Key','Bombette'],['blue-house-open','Bombette'],['Super Boots','Sushie'],['Ultra Boots','Sushie']],'Lakilester'">Invisible block next to visible ? block</label></li>
+                                <li><label><input data-map-group="maps-sewers-spiny" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Odd Key','Bombette'],['blue-house-open','Bombette'],['Super Boots','Sushie'],['Ultra Boots','Sushie']],'Lakilester'">[Coinsanity] ? Block by stone block</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1168,14 +1168,14 @@
                             <h3>Switch Bridge #1</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox">? Block</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox">Kooper item</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Kooper item</label></li>
                                 <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox">Item behind small fence</label></li>
                             </ul>
                         </div>
                         <div id="maps-pleasant-path-koopa" style="display:none;">
                             <h3>Outside Koopa Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox">[Panel] Middle of three pillars</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of three pillars</label></li>
                                 <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox">Item behind right-most pillar</label></li>
                                 <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox">Break brick boxes (left, right, middle)</label></li>
                             </ul>
@@ -1183,16 +1183,16 @@
                         <div id="maps-pleasant-path-bridge2" style="display:none;">
                             <h3>Switch Bridge #2</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox">[Panel] Under 5 coins / items</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Under 5 coins / items</label></li>
                                 <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox">[Coinsanity] 5 items at start of room</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox">Item on brick block</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox">Hidden ? block after bridge</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Kooper','Ultra Boots']">Item on brick block</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Hidden ? block after bridge</label></li>
                             </ul>
                         </div>
                         <div id="maps-pleasant-path-fortress" style="display:none;">
                             <h3>Path to Fortress</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-pleasant-path-fortress" autocomplete="off" type="checkbox">Item in first tree</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-fortress" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Item in first tree</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1207,18 +1207,18 @@
                         <div id="maps-koopa-village-behind-kooper" style="display:none;">
                             <h3>Behind Kooper's House</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-koopa-village-behind-kooper" autocomplete="off" type="checkbox">On tall stump</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-behind-kooper" autocomplete="off" type="checkbox" data-requirements-glitchless="['Kooper','Parakarry']">On tall stump</label></li>
                             </ul>
                         </div>
                         <div id="maps-koopa-village-west" style="display:none;">
                             <h3>Koopa Village West</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Panel] Left of tree</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Mort T.</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Koover 1 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Letter] Koover 2 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Koot] Far right bush after Koopa Koot requests his Wallet</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Koot] Second bush from left after Koopa Koot requests his Glasses</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Left of tree</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="'Mort T. (Koopa Village Inn)'">[Letter] Mort T.</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koover 1'">[Letter] Koover 1 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koover 2'">[Letter] Koover 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph'">[Koot] Far right bush after Koopa Koot requests his Wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta'">[Koot] Second bush from left after Koopa Koot requests his Glasses</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Bottom bush on left side</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Third bush from the right</label></li>
                             </ul>
@@ -1226,33 +1226,33 @@
                         <div id="maps-koopa-village-east" style="display:none;">
                             <h3>Koopa Village East</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Letter] Kolorado</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kolorado'">[Letter] Kolorado</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Kolorado's wife after starting Koopa Koot's first favor</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Legends to Koopa Koot</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Sleepy Sheep (first item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Sleepy Sheep (second item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's Tape</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot Koopa Tea</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Luigi's Autograph to Koopa Koot</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's wallet</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Tasty Tonic</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Merluvlee's Autograph to Koopa Koot</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Talk to Koopa Koot after reading the news in Toad Town</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Life Shroom (first item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Life Shroom (second item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Nutty Cake</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Koopa Koot after calming the Bob-ombs</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot the Old Photo</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot Koopasta</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Return Koopa Koot's glasses</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot a Lime</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Kooky Cookie</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot his package</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] [Coinsanity] Give Koopa Koot a Coconut</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Give Koopa Koot the Red Jar</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koopa Legends'">[Koot] [Coinsanity] Return Koopa Legends to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koopa Legends','Sleepy Sheep'">[Koot] [Coinsanity] Give Koopa Koot a Sleepy Sheep (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koopa Legends','Sleepy Sheep'">[Koot] Give Koopa Koot a Sleepy Sheep (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape'">[Koot] [Coinsanity] Return Koopa Koot's Tape</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea'">[Koot] Give Koopa Koot Koopa Tea</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph'">[Koot] [Coinsanity] Give Luigi's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet'">[Koot] [Coinsanity] Return Koopa Koot's wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic'">[Koot] [Coinsanity] Give Koopa Koot a Tasty Tonic</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph'">[Koot] Give Merluvlee's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph'">[Koot] [Coinsanity] Talk to Koopa Koot after reading the news in Toad Town</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom'">[Koot] [Coinsanity] Give Koopa Koot a Life Shroom (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom'">[Koot] Give Koopa Koot a Life Shroom (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake'">[Koot] [Coinsanity] Give Koopa Koot a Nutty Cake</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette'">[Koot] Talk to Koopa Koot after calming the Bob-ombs</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo'">[Koot] [Coinsanity] Give Koopa Koot the Old Photo</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta'">[Koot] [Coinsanity] Give Koopa Koot Koopasta</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses'">[Koot] [Coinsanity] Return Koopa Koot's glasses</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime'">[Koot] Give Koopa Koot a Lime</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie'">[Koot] [Coinsanity] Give Koopa Koot a Kooky Cookie</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package'">[Koot] [Coinsanity] Give Koopa Koot his package</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut'">[Koot] [Coinsanity] Give Koopa Koot a Coconut</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut','Red Jar'">[Koot] Give Koopa Koot the Red Jar</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">First bush on left</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Give Kooper his shell</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Give Artifact to Kolorado</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper\'s Shell'">Give Kooper his shell</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Artifact',['Mamar',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Give Artifact to Kolorado</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Item on top of brick block on right (after defeating fuzzies)</label></li>
                             </ul>
                         </div>
@@ -1262,46 +1262,46 @@
                         <div id="maps-kbf-entrance" style="display:none;">
                             <h3>Entrance</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox">Defeat Koopa by first locked door</label></li>
-                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox">Top of room guarded by Bob-omb</label></li>
+                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Defeat Koopa by first locked door</label></li>
+                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',{'chapter':1,'keys':4}">Top of room guarded by Bob-omb</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-cannons" style="display:none;">
                             <h3>Cannons</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-cannons" autocomplete="off" type="checkbox">? Block behind bombable rock</label></li>
+                                <li><label><input data-map-group="maps-kbf-cannons" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette',{'chapter':1,'keys':4}">? Block behind bombable rock</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-puzzle-room" style="display:none;">
                             <h3>Kooper Puzzle Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox">Left Jail Cell</label></li>
-                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox">Middle Jail Cell</label></li>
-                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox">Right Jail Cell</label></li>
+                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette',{'chapter':1,'keys':3}">Left Jail Cell</label></li>
+                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',{'chapter':1,'keys':1}">Middle Jail Cell</label></li>
+                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette',{'chapter':1,'keys':1}">Right Jail Cell</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-outside" style="display:none;">
                             <h3>Outside Koopa Bros. Fortress</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-outside" autocomplete="off" type="checkbox">Inside chest on ledge from bombable wall on previous screen</label></li>
+                                <li><label><input data-map-group="maps-kbf-outside" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette'">Inside chest on ledge from bombable wall on previous screen</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-refund" style="display:none;">
                             <h3>Outside Chest</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-refund" autocomplete="off" type="checkbox">Chest after bombable wall in trap room</label></li>
+                                <li><label><input data-map-group="maps-kbf-refund" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette',{'chapter':1,'keys':2}">Chest after bombable wall in trap room</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-firebars" style="display:none;">
                             <h3>Firebars</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-firebars" autocomplete="off" type="checkbox">Item at end of room</label></li>
+                                <li><label><input data-map-group="maps-kbf-firebars" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',{'chapter':1,'keys':1}">Item at end of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-jail" style="display:none;">
                             <h3>Jail</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-jail" autocomplete="off" type="checkbox">Bombette</label></li>
+                                <li><label><input data-map-group="maps-kbf-jail" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',[[{'chapter':1,'keys':1},'Bombette'],{'chapter':1,'keys':2}]">Bombette</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1310,50 +1310,50 @@
                         <div id="maps-mt-rugged-letter3" style="display:none;">
                             <h3>Letter 3</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">[Coinsanity] ? Block left after taking spring</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">[Coinsanity] Circle of items across Parakarry gap</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">[Coinsanity] 2 items on ground below Parakarry gap</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">? Block by Cleft when entering room</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">Chest in cave</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">Item across Parakarry gap</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">? Block past Cleft after spring</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox">Item on far right ledge</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block left after taking spring</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">[Coinsanity] Circle of items across Parakarry gap</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] 2 items on ground below Parakarry gap</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">? Block by Cleft when entering room</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Chest in cave</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Item across Parakarry gap</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">? Block past Cleft after spring</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item on far right ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-letter1" style="display:none;">
                             <h3>Letter 1</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox">[Panel] By wall near end of slide</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox">Item on first ledge</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox">Item on second ledge</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By wall near end of slide</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],['Kooper','Parakarry']">Item on first ledge</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Item on second ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-seed" style="display:none;">
                             <h3>Seed Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox">Bub-ulb</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox">Item on support beam when falling through opening at the top</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Bub-ulb</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item on support beam when falling through opening at the top</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-buzzar" style="display:none;">
                             <h3>Buzzar</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-buzzar" autocomplete="off" type="checkbox">Item on ground by Cleft</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-buzzar" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item on ground by Cleft</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-train" style="display:none;">
                             <h3>Train Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox">Item in top most bush</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox">Give three letters to Parakarry</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item in top most bush</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Give three letters to Parakarry</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-whacka" style="display:none;">
                             <h3>Whacka</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox">[Coinsanity] Three items on slide</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox">Hit Whacka</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox">? Block</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] Three items on slide</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Hit Whacka</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">? Block</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1362,138 +1362,138 @@
                         <div id="maps-desert-top-left" style="display:none;">
                             <h3>Two ? Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox">Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Left ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-pokey" style="display:none;">
                             <h3>Pokey Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-pokey" autocomplete="off" type="checkbox">Behind cactus at top of room</label></li>
+                                <li><label><input data-map-group="maps-desert-pokey" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Behind cactus at top of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-thunder-rage" style="display:none;">
                             <h3>Thunder Rage</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-thunder-rage" autocomplete="off" type="checkbox">Hidden block above rock on right side</label></li>
+                                <li><label><input data-map-group="maps-desert-thunder-rage" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block above rock on right side</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-above-runaway-pay" style="display:none;">
                             <h3>Two ? Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox">Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Right ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-hammer-block" style="display:none;">
                             <h3>Hammer Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox">Hammer yellow block once</label></li>
-                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox">Hammer yellow block five times</label></li>
-                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox">Hammer yellow block ten times</label></li>
+                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hammer yellow block once</label></li>
+                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hammer yellow block five times</label></li>
+                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hammer yellow block ten times</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-five-block" style="display:none;">
                             <h3>Five ? Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox">[Coinsanity] Top-Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox">[Coinsanity] Top-Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox">[Coinsanity] Bottom-Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox">[Coinsanity] Bottom-Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox">Center ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Top-Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Top-Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Bottom-Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Bottom-Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Center ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-runaway-pay" style="display:none;">
                             <h3>Runaway Pay</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-runaway-pay" autocomplete="off" type="checkbox">Hidden block in the middle of three trees</label></li>
+                                <li><label><input data-map-group="maps-desert-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block in the middle of three trees</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-camp" style="display:none;">
                             <h3>Kolorado's Camp</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-camp" autocomplete="off" type="checkbox">Tree at camp location after saving Mamar</label></li>
+                                <li><label><input data-map-group="maps-desert-camp" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Mamar'">Tree at camp location after saving Mamar</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-stone-cactus" style="display:none;">
                             <h3>Stone Cactus</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-stone-cactus" autocomplete="off" type="checkbox">[Panel] Below stone cactus</label></li>
+                                <li><label><input data-map-group="maps-desert-stone-cactus" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Below stone cactus</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-nomadimouse" style="display:none;">
                             <h3>Nomadimouse</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-nomadimouse" autocomplete="off" type="checkbox">[Letter] Nomadimouse</label></li>
+                                <li><label><input data-map-group="maps-desert-nomadimouse" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Nomadimouse'">[Letter] Nomadimouse</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-outside-outpost" style="display:none;">
                             <h3>Outside Outpost</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-outside-outpost" autocomplete="off" type="checkbox">Far right tree</label></li>
+                                <li><label><input data-map-group="maps-desert-outside-outpost" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Far right tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-outpost-west" style="display:none;">
                             <h3>Dry Dry Outpost West</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">[Letter] Shop (Chain)</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">[Koot] Buy Dusty Hammer, Dried Pasta, Dusty Hammer, Dried Shroom after Koopa Koot requests Red Red Jar</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox">Turn in Lyrics at far right house</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Dry Dry Shop'">[Letter] Shop (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut'">[Koot] Buy Dusty Hammer, Dried Pasta, Dusty Hammer, Dried Shroom after Koopa Koot requests Red Red Jar</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Lyrics'">Turn in Lyrics at far right house</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-outpost-east" style="display:none;">
                             <h3>Dry Dry Outpost East</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Panel] On rooftops</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Letter] Mr. E (Chain)</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">[Koot] Talk to Merlee after Merluvlee requests Crystal Ball</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">Item on rooftops</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox">Talk to Moustafa after buying Dried Shroom + Dusty Hammer</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] On rooftops</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Mr. E'">[Letter] Mr. E (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic'">[Koot] Talk to Merlee after Merluvlee requests Crystal Ball</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item on rooftops</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Talk to Moustafa after buying Dried Shroom + Dusty Hammer</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-below-cactus" style="display:none;">
                             <h3>? Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-below-cactus" autocomplete="off" type="checkbox">[Coinsanity] ? Block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-below-cactus" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] ? Block in middle of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-bump-attack" style="display:none;">
                             <h3>Spin Attack</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox">Item on ledge (take Tweester in room down left from here)</label></li>
-                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox">Item on brick block, requires Kooper or Ultra Boots</label></li>
+                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item on ledge (take Tweester in room down left from here)</label></li>
+                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Kooper','Ultra Boots']">Item on brick block, requires Kooper or Ultra Boots</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-life-shroom" style="display:none;">
                             <h3>Life Shroom</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox">[Coinsanity] ? Block in middle of room</label></li>
-                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox">Hidden block directly above other ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] ? Block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block directly above other ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-before-oasis" style="display:none;">
                             <h3>Before Oasis</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-before-oasis" autocomplete="off" type="checkbox">Item behind bush on right side of room</label></li>
+                                <li><label><input data-map-group="maps-desert-before-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item behind bush on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-oasis" style="display:none;">
                             <h3>Oasis</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox">Lemon Tree</label></li>
-                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox">Lime Tree</label></li>
+                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Lemon Tree</label></li>
+                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Lime Tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-fxc" style="display:none;">
                             <h3>Attack FX C</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-fxc" autocomplete="off" type="checkbox">Hidden block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-fxc" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block in middle of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-opposite-fxc" style="display:none;">
                             <h3>? Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-opposite-fxc" autocomplete="off" type="checkbox">[Coinsanity] ? Block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-opposite-fxc" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] ? Block in middle of room</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1502,62 +1502,62 @@
                         <div id="maps-ruins-pokey-hall" style="display:none;">
                             <h3>Pokey Hall</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-pokey-hall" autocomplete="off" type="checkbox">Inside middle coffin</label></li>
+                                <li><label><input data-map-group="maps-ruins-pokey-hall" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone'">Inside middle coffin</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-sand-switch-2" style="display:none;">
                             <h3>Sand Switch Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-sand-switch-2" autocomplete="off" type="checkbox">Bottom right corner after lowering sand</label></li>
+                                <li><label><input data-map-group="maps-ruins-sand-switch-2" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bombette','Parakarry','Pulse Stone',{'chapter':2,'keys':1}">Bottom right corner after lowering sand</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-sand-room1" style="display:none;">
                             <h3>Sand Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-sand-room1" autocomplete="off" type="checkbox">Item on elevated platform</label></li>
+                                <li><label><input data-map-group="maps-ruins-sand-room1" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':1}">Item on elevated platform</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-key-room1" style="display:none;">
                             <h3>Key Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-key-room1" autocomplete="off" type="checkbox">Item on elevated platform</label></li>
+                                <li><label><input data-map-group="maps-ruins-key-room1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bombette','Parakarry','Pulse Stone',{'chapter':2,'keys':1}">Item on elevated platform</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-super-hammer" style="display:none;">
                             <h3>Super Hammer</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-super-hammer" autocomplete="off" type="checkbox">Item in chest behind wall on ledge above Super Hammer chest</label></li>
+                                <li><label><input data-map-group="maps-ruins-super-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Item in chest behind wall on ledge above Super Hammer chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-pokey-room" style="display:none;">
                             <h3>Pokey Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox">Defeat all three Pokey's after hitting ? Block</label></li>
-                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox">On ledge behind hammer block</label></li>
+                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':2}">Defeat all three Pokey's after hitting ? Block</label></li>
+                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">On ledge behind hammer block</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-chomp-room-1" style="display:none;">
                             <h3>Chomp Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-chomp-room-1" autocomplete="off" type="checkbox">Item on pedestal</label></li>
+                                <li><label><input data-map-group="maps-ruins-chomp-room-1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bombette','Parakarry',['Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':3}">Item on pedestal</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-chomp-room-2" style="display:none;">
                             <h3>Chomp Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-chomp-room-2" autocomplete="off" type="checkbox">Item on pedestal</label></li>
+                                <li><label><input data-map-group="maps-ruins-chomp-room-2" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Item on pedestal</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-chomp-room-3" style="display:none;">
                             <h3>Chomp Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-chomp-room-3" autocomplete="off" type="checkbox">Item on pedestal</label></li>
+                                <li><label><input data-map-group="maps-ruins-chomp-room-3" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':4}">Item on pedestal</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-wall-stairs" style="display:none;">
                             <h3>Wall Stairs</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-wall-stairs" autocomplete="off" type="checkbox">Item on ledge, reachable by breaking block and hitting switch</label></li>
+                                <li><label><input data-map-group="maps-ruins-wall-stairs" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':3}">Item on ledge, reachable by breaking block and hitting switch</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1587,41 +1587,41 @@
                         <div id="maps-boo-mansion-bow" style="display:none;">
                             <h3>Bow's Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-bow" autocomplete="off" type="checkbox">Bow</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-bow" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">Bow</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-weight" style="display:none;">
                             <h3>Weight Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-weight" autocomplete="off" type="checkbox">Chest guarded by Boo</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-weight" autocomplete="off" type="checkbox"data-requirements-glitchless="'Record'">Chest guarded by Boo</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-main" style="display:none;">
                             <h3>Main Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Panel] By couch</label></li>
-                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Letter] Franky (Chain)</label></li>
-                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox">[Koot] Talk to Franky after Koopa Koot requests the Old Photo</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By couch</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="'Franky (Boo\'s Mansion Entrance)'">[Letter] Franky (Chain)</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette'">[Koot] Talk to Franky after Koopa Koot requests the Old Photo</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-record" style="display:none;">
                             <h3>Record Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-record" autocomplete="off" type="checkbox">[Panel] Middle of room</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-record" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of room</label></li>
                                 <li><label><input data-map-group="maps-boo-mansion-record" autocomplete="off" type="checkbox">Open middle cabinets and do minigame</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-trap" style="display:none;">
                             <h3>Trap Chest</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-trap" autocomplete="off" type="checkbox">[Panel] In front of grandfather clock downstairs</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-trap" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of grandfather clock downstairs</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-pixels" style="display:none;">
                             <h3>Pixel Mario Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-pixels" autocomplete="off" type="checkbox">Left crate on right side of room</label></li>
-                                <li><label><input data-map-group="maps-boo-mansion-pixels" autocomplete="off" type="checkbox">Right crate on right side of room under other crate</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-pixels" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots']">Left crate on right side of room</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-pixels" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots']">Right crate on right side of room under other crate</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-outside" style="display:none;">
@@ -1634,27 +1634,27 @@
                         <div id="maps-boo-mansion-library" style="display:none;">
                             <h3>Library</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-library" autocomplete="off" type="checkbox">Item on right bookshelf</label></li>
-                                <li><label><input data-map-group="maps-boo-mansion-library" autocomplete="off" type="checkbox">Bottom crate</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-library" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots'],'Parakarry'">Item on right bookshelf</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-library" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots']">Bottom crate</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-shop" style="display:none;">
                             <h3>Above Shop</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-shop" autocomplete="off" type="checkbox">Right crate on left side of room</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-shop" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots'],['Weight','Bombette']">Right crate on left side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-shop-real" style="display:none;">
                             <h3>Shop</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-shop-real" autocomplete="off" type="checkbox">[Letter] Igor</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-shop-real" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots'],['Weight','Bombette'],'Igor (Boo\'s Mansion Shop)'">[Letter] Igor</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-boots" style="display:none;">
                             <h3>Super Boots</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-boo-mansion-boots" autocomplete="off" type="checkbox">[Panel] On left near Boo</label></li>
-                                <li><label><input data-map-group="maps-boo-mansion-boots" autocomplete="off" type="checkbox">Bottom left crate</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-boots" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer'],['Weight','Bombette']">[Panel] On left near Boo</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-boots" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots'],['Weight','Bombette']">Bottom left crate</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1663,32 +1663,32 @@
                         <div id="maps-gusty-gulch-gate" style="display:none;">
                             <h3>Gate</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-gusty-gulch-gate" autocomplete="off" type="checkbox">[Panel] Near gate</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Near gate</label></li>
                             </ul>
                         </div>
                         <div id="maps-gusty-gulch-village1" style="display:none;">
                             <h3>Village 1</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox">[Coinsanity] Block in far right house</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox">[Koot] Talk to Boo near Save Block after Koopa Koot requests a Package</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">[Coinsanity] Block in far right house</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait',5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie'">[Koot] Talk to Boo near Save Block after Koopa Koot requests a Package</label></li>
                             </ul>
                         </div>
                         <div id="maps-gusty-gulch-1" style="display:none;">
-                            <h3>Gluch 1</h3>
+                            <h3>Gulch 1</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox">[Coinsanity] First ? Block</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox">[Coinsanity] Upper ? Block near goomba</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox">Item on ledge (use Kooper)</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox">? Block in middle near goomba</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox">Item in front of log</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">[Coinsanity] First ? Block</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">[Coinsanity] Upper ? Block near goomba</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Kooper'">Item on ledge (use Kooper)</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">? Block in middle near goomba</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">Item in front of log</label></li>
                             </ul>
                         </div>
                         <div id="maps-gusty-gulch-2" style="display:none;">
-                            <h3>Gluch 2</h3>
+                            <h3>Gulch 2</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-gusty-gulch-2" autocomplete="off" type="checkbox">[Coinsanity] ? Block by exit</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-2" autocomplete="off" type="checkbox">? Block by goomba</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-2" autocomplete="off" type="checkbox">Item behind rock near exit</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-2" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry'">[Coinsanity] ? Block by exit</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-2" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry'">? Block by goomba</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-2" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry'">Item behind rock near exit</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1697,50 +1697,50 @@
                         <div id="maps-tubba-sleeping-clubba" style="display:none;">
                             <h3>Sleeping Clubba's</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-sleeping-clubba" autocomplete="off" type="checkbox">Item at end of hall</label></li>
+                                <li><label><input data-map-group="maps-tubba-sleeping-clubba" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':2}">Item at end of hall</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-stairwell" style="display:none;">
                             <h3>Stairwell</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-stairwell" autocomplete="off" type="checkbox">? Block at bottom of staircase</label></li>
+                                <li><label><input data-map-group="maps-tubba-stairwell" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':2}">? Block at bottom of staircase</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-behind-clock" style="display:none;">
                             <h3>Behind Clock</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-behind-clock" autocomplete="off" type="checkbox">[Coinsanity] 6 items on bed</label></li>
-                                <li><label><input data-map-group="maps-tubba-behind-clock" autocomplete="off" type="checkbox">Behind wall on shelf at left side of room</label></li>
+                                <li><label><input data-map-group="maps-tubba-behind-clock" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':1}">[Coinsanity] 6 items on bed</label></li>
+                                <li><label><input data-map-group="maps-tubba-behind-clock" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':1}">Behind wall on shelf at left side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-spikes" style="display:none;">
                             <h3>Spike Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-spikes" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-tubba-spikes" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':1},['Bow','Lakilester']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-study" style="display:none;">
                             <h3>Study</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-study" autocomplete="off" type="checkbox">On table</label></li>
+                                <li><label><input data-map-group="maps-tubba-study" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry'">On table</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-spring" style="display:none;">
                             <h3>Spring Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-spring" autocomplete="off" type="checkbox">On left side, break panels in room above behind bombable wall</label></li>
+                                <li><label><input data-map-group="maps-tubba-spring" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':1},'Bombette','Super Boots'">On left side, break panels in room above behind bombable wall</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-big-table" style="display:none;">
                             <h3>Table</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-big-table" autocomplete="off" type="checkbox">On table, fall down from above</label></li>
+                                <li><label><input data-map-group="maps-tubba-big-table" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry',{'chapter':3,'keys':1}">On table, fall down from above</label></li>
                             </ul>
                         </div>
                         <div id="maps-tubba-basement-chest" style="display:none;">
                             <h3>Basement Chest</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-tubba-basement-chest" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-tubba-basement-chest" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait','Parakarry','Super Boots'">Chest</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1749,123 +1749,123 @@
                         <div id="maps-toybox-playroom" style="display:none;">
                             <h3>Playroom</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-playroom" autocomplete="off" type="checkbox">Left hidden block</label></li>
-                                <li><label><input data-map-group="maps-toybox-playroom" autocomplete="off" type="checkbox">Right hidden block</label></li>
-                                <li><label><input data-map-group="maps-toybox-playroom" autocomplete="off" type="checkbox">Items held by Shy Guys (all of them)</label></li>
+                                <li><label><input data-map-group="maps-toybox-playroom" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Left hidden block</label></li>
+                                <li><label><input data-map-group="maps-toybox-playroom" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Right hidden block</label></li>
+                                <li><label><input data-map-group="maps-toybox-playroom" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Items held by Shy Guys (all of them)</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-anti-guy" style="display:none;">
                             <h3>Anti Guy</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-anti-guy" autocomplete="off" type="checkbox">[Coinsanity] ? Block on left side</label></li>
-                                <li><label><input data-sync="anti-guy" data-map-group="maps-toybox-anti-guy" autocomplete="off" type="checkbox">Anti Guy Chest (in logic if you can make a Lemon Candy [Lemon + Cake Mix])</label></li>
-                                <li><label><input data-map-group="maps-toybox-anti-guy" autocomplete="off" type="checkbox">Hidden block on right side</label></li>
+                                <li><label><input data-map-group="maps-toybox-anti-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] ? Block on left side</label></li>
+                                <li><label><input data-sync="anti-guy" data-map-group="maps-toybox-anti-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Anti Guy Chest (in logic if you can make a Lemon Candy [Lemon + Cake Mix])</label></li>
+                                <li><label><input data-map-group="maps-toybox-anti-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Hidden block on right side</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-blue-station" style="display:none;">
                             <h3>Blue Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-blue-station" autocomplete="off" type="checkbox">[Panel] In front of station</label></li>
-                                <li><label><input data-map-group="maps-toybox-blue-station" autocomplete="off" type="checkbox">Hidden block on right side</label></li>
+                                <li><label><input data-map-group="maps-toybox-blue-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of station</label></li>
+                                <li><label><input data-map-group="maps-toybox-blue-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Hidden block on right side</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-block-city" style="display:none;">
                             <h3>Block City</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">[Coinsanity] 3 items on left spring</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">[Coinsanity] 5 items on elevated spring</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">[Coinsanity] ? Block on left side of wall</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">[Coinsanity] ? Block on right side of wall that can be jumped across</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">Item behind fallen blocks</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">Item on roof of left house</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">? Block on platform</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">Item that Kammy spawns</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] 3 items on left spring</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] 5 items on elevated spring</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] ? Block on left side of wall</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] ? Block on right side of wall that can be jumped across</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Item behind fallen blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Parakarry'">Item on roof of left house</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">? Block on platform</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Item that Kammy spawns</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-gourmet-guy" style="display:none;">
                             <h3>Gourmet Guy</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox">Hidden block left after Gourmet Guy arch</label></li>
-                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox">Hidden block between two other ? Blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block left after Gourmet Guy arch</label></li>
+                                <li><label><input data-map-group="maps-toybox-gourmet-guy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block between two other ? Blocks</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-tracks-hallway" style="display:none;">
                             <h3>Tracks Hallway</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-tracks-hallway" autocomplete="off" type="checkbox">[Coinsanity] ? Block before Spy Guy</label></li>
-                                <li><label><input data-map-group="maps-toybox-tracks-hallway" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block by Groove Guy</label></li>
-                                <li><label><input data-map-group="maps-toybox-tracks-hallway" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block by Groove Guy</label></li>
+                                <li><label><input data-map-group="maps-toybox-tracks-hallway" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">[Coinsanity] ? Block before Spy Guy</label></li>
+                                <li><label><input data-map-group="maps-toybox-tracks-hallway" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Left ? Block by Groove Guy</label></li>
+                                <li><label><input data-map-group="maps-toybox-tracks-hallway" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Right ? Block by Groove Guy</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-pink-station" style="display:none;">
                             <h3>Pink Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-pink-station" autocomplete="off" type="checkbox">[Panel] In front of station</label></li>
-                                <li><label><input data-map-group="maps-toybox-pink-station" autocomplete="off" type="checkbox">Chest on right side</label></li>
-                                <li><label><input data-map-group="maps-toybox-pink-station" autocomplete="off" type="checkbox">Hidden block by pink switch</label></li>
+                                <li><label><input data-map-group="maps-toybox-pink-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of station</label></li>
+                                <li><label><input data-map-group="maps-toybox-pink-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest on right side</label></li>
+                                <li><label><input data-map-group="maps-toybox-pink-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block by pink switch</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-playhouse" style="display:none;">
                             <h3>Playhouse</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox">[Coinsanity] ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox">Chest on wall</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox">Chest after door</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox">Item that Kammy spawns</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox">Chest at end of room</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">[Coinsanity] ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest on wall</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest after door</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Item that Kammy spawns</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest at end of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-green-station" style="display:none;">
                             <h3>Green Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-green-station" autocomplete="off" type="checkbox">[Panel] In front of station</label></li>
-                                <li><label><input data-map-group="maps-toybox-green-station" autocomplete="off" type="checkbox">Hidden block in upper right corner</label></li>
+                                <li><label><input data-map-group="maps-toybox-green-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of station</label></li>
+                                <li><label><input data-map-group="maps-toybox-green-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block in upper right corner</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-treadmill" style="display:none;">
                             <h3>Treadmill</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">[Coinsanity] 3 items on first treadmill</label></li>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">[Coinsanity] 3 items on second treadmill</label></li>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">[Coinsanity] Ring of coins inside fort after moving blocks</label></li>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">Item held by Shy Guy after treadmills</label></li>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">Middle item inside fort after moving blocks</label></li>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">Item that Kammy spawns</label></li>
-                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] 3 items on first treadmill</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] 3 items on second treadmill</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bow','Toy Train','Cake'">[Coinsanity] Ring of coins inside fort after moving blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bow','Toy Train','Cake'">Item held by Shy Guy after treadmills</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bow','Toy Train','Cake'">Middle item inside fort after moving blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bow','Toy Train','Cake','Parakarry'">Item that Kammy spawns</label></li>
+                                <li><label><input data-map-group="maps-toybox-treadmill" autocomplete="off" type="checkbox" data-requirements-glitchless="'Bow','Toy Train','Cake','Parakarry'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-lantern-ghost" style="display:none;">
                             <h3>Lantern Ghost</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-lantern-ghost" autocomplete="off" type="checkbox">Watt</label></li>
+                                <li><label><input data-map-group="maps-toybox-lantern-ghost" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Watt</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-moving-platforms" style="display:none;">
                             <h3>Moving Platforms</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox">Hidden block by first elevator</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox">Hidden block between two other ? blocks</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox">Hidden block by door to Lantern Ghost room</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block by first elevator</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block between two other ? blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block by door to Lantern Ghost room</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-red-station" style="display:none;">
                             <h3>Red Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox">[Panel] In front of station</label></li>
-                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox">Hidden block on left side</label></li>
+                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of station</label></li>
+                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block on left side</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-barricade" style="display:none;">
                             <h3>Shy Guy Barricade</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox">[Coinsanity] ? Block just past barricade</label></li>
-                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox">Item on top of brick block</label></li>
-                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox">? Block at end of room</label></li>
+                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette'">[Coinsanity] ? Block just past barricade</label></li>
+                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette',['Kooper','Ultra Boots']">Item on top of brick block</label></li>
+                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette'">? Block at end of room</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1874,122 +1874,122 @@
                         <div id="maps-yoshi-ambush-room" style="display:none;">
                             <h3>Ambush Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-ambush-room" autocomplete="off" type="checkbox">[Panel] Near middle of room</label></li>
+                                <li><label><input data-map-group="maps-yoshi-ambush-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Near middle of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-raph" style="display:none;">
                             <h3>Raph's Tree</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox">Item on the outside Raph's Tree</label></li>
-                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox">Talk to Raphael at the top</label></li>
+                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Item on the outside Raph's Tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Talk to Raphael at the top</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-vine-room" style="display:none;">
                             <h3>Vine Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox">Second Tree vine</label></li>
-                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox">Last Tree vine</label></li>
+                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Second Tree vine</label></li>
+                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Last Tree vine</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-block-puzzle" style="display:none;">
                             <h3>Block Puzzle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-block-puzzle" autocomplete="off" type="checkbox">Hidden block near first push block</label></li>
+                                <li><label><input data-map-group="maps-yoshi-block-puzzle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Hidden block near first push block</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-deep-jungle" style="display:none;">
                             <h3>Deep Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox">Hidden block near bell plant</label></li>
-                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox">Tree vine near bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Hidden block near bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Tree vine near bell plant</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-lightblue-yoshi" style="display:none;">
                             <h3>Light-Blue Yoshi</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-lightblue-yoshi" autocomplete="off" type="checkbox">Item under water</label></li>
+                                <li><label><input data-map-group="maps-yoshi-lightblue-yoshi" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item under water</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-nw-jungle" style="display:none;">
                             <h3>NW Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-nw-jungle" autocomplete="off" type="checkbox">Item in tree by right side exit</label></li>
+                                <li><label><input data-map-group="maps-yoshi-nw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item in tree by right side exit</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-ne-jungle" style="display:none;">
                             <h3>NE Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-ne-jungle" autocomplete="off" type="checkbox">[Coinsanity] Item under water on right side of room</label></li>
+                                <li><label><input data-map-group="maps-yoshi-ne-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">[Coinsanity] Item under water on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-whale" style="display:none;">
                             <h3>Whale</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox">[Coinsanity] 2 items on spinning flower</label></li>
-                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox">Coconut tree</label></li>
-                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox">Item behind bush near top of screen</label></li>
+                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] 2 items on spinning flower</label></li>
+                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item behind bush near top of screen</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-sw-jungle" style="display:none;">
                             <h3>SW Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox">[Coinsanity] Three items under water</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox">Hidden block near exit to NW Jungle</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">[Coinsanity] Three items under water</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Hidden block near exit to NW Jungle</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-se-jungle" style="display:none;">
                             <h3>SE Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-se-jungle" autocomplete="off" type="checkbox">? Block on island</label></li>
+                                <li><label><input data-map-group="maps-yoshi-se-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">? Block on island</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-sushie" style="display:none;">
                             <h3>Sushie Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox">Sushie</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox">Item on top right island</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox">Item in tree on top right island</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox">Chest after saving Misstar</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Sushie</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item on top right island</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item in tree on top right island</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Misstar'">Chest after saving Misstar</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-beach" style="display:none;">
                             <h3>Beach</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">[Coinsanity] 2 items on spinning flower</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 1 (far left)</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 2</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Hidden block by bell plant</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 3</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Item on rock formation</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 4</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Hidden block by bell plant</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 5</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 6 (last tree)</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox">Coconut tree 6 (last tree, reload room for extra check)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] 2 items on spinning flower</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 1 (far left)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 2</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Hidden block by bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 3</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item on rock formation</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 4</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Hidden block by bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 5</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 6 (last tree)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 6 (last tree, reload room for extra check)</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-west-village" style="display:none;">
                             <h3>West Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox">[Panel] In front of raven statue</label></li>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox">Talk to Yoshi Chief after saving all the kids</label></li>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox">Left Coconut tree</label></li>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox">Right Coconut tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Panel] In front of raven statue</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie'">Talk to Yoshi Chief after saving all the kids</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Left Coconut tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Right Coconut tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-east-village" style="display:none;">
                             <h3>East Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox">[Letter] Red Yoshi Kid (Chain)</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox">Give a Tayce T. item to Yellow Adult Yoshi</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox">Give the volcano vase to Kolorado</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox">Coconut tree on right side of room</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Red Yoshi Kid'">[Letter] Red Yoshi Kid (Chain)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie'">Give a Tayce T. item to Yellow Adult Yoshi</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie','Volcano Vase','Misstar'">Give the volcano vase to Kolorado</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-volcano" style="display:none;">
                             <h3>Outside Volcano</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-volcano" autocomplete="off" type="checkbox">Item behind large tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-volcano" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item behind large tree</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1998,43 +1998,43 @@
                         <div id="maps-lavalav-hub" style="display:none;">
                             <h3>Hub Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox">[Coinsanity] ? Block 1</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox">[Coinsanity] ? Block 2</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox">[Coinsanity] ? Block 3</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox">[Coinsanity] ? Block 4</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox">Item on top of brick block</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox">Item on platform halfway down second zip line</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 1</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 2</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 3</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 4</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Kooper','Ultra Boots']">Item on top of brick block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Item on platform halfway down second zip line</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-zipline" style="display:none;">
                             <h3>Zipline</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-zipline" autocomplete="off" type="checkbox">[Panel] Right side of lower level</label></li>
+                                <li><label><input data-map-group="maps-lavalav-zipline" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right side of lower level</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-save" style="display:none;">
                             <h3>Save Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-save" autocomplete="off" type="checkbox">[Panel] Left of heart block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-save" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Left of heart block</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-deadend" style="display:none;">
                             <h3>Deadend</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox">Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox">Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Right ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-lava-puzzle" style="display:none;">
                             <h3>Lava Puzzle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-lava-puzzle" autocomplete="off" type="checkbox">Hidden block on right side of room</label></li>
+                                <li><label><input data-map-group="maps-lavalav-lava-puzzle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Hidden block on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-dizzy" style="display:none;">
                             <h3>Dizzy Stomp</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-dizzy" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-lavalav-dizzy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Chest</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -2043,108 +2043,108 @@
                         <div id="maps-flower-fields-clouds" style="display:none;">
                             <h3>In The Clouds</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-clouds" autocomplete="off" type="checkbox">Ride cloud elevator up to item</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-clouds" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Lakilester',['Super Boots','Ultra Boots'],'Magical Bean','Fertile Soil','Miracle Water'">Ride cloud elevator up to item</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-lakilester" style="display:none;">
                             <h3>Lakilester</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-lakilester" autocomplete="off" type="checkbox">Lakilester</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-lakilester" autocomplete="off" type="checkbox">Item in grass</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-lakilester" autocomplete="off" type="checkbox">Item in crevasse</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-lakilester" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],['Lakilester','Bubble Berry'],'Bombette'">Lakilester</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-lakilester" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],['Lakilester','Bubble Berry']">Item in grass</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-lakilester" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],['Lakilester','Bubble Berry']">Item in crevasse</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-bubble-plant" style="display:none;">
                             <h3>Bubble Plant</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-plant" autocomplete="off" type="checkbox">Item on ledge</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-plant" autocomplete="off" type="checkbox">Item in vines immediately below ledge item</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-plant" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],['Lakilester','Bubble Berry']">Item on ledge</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-plant" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">Item in vines immediately below ledge item</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-elevators" style="display:none;">
                             <h3>Elevators</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-elevators" autocomplete="off" type="checkbox">Item in second vine (jump to trigger it)</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-elevators" autocomplete="off" type="checkbox">Item from ground pounding opposite side from partner upgrade block</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-elevators" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">Item in second vine (jump to trigger it)</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-elevators" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Lakilester',['Super Boots','Ultra Boots']">Item from ground pounding opposite side from partner upgrade block</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-logs" style="display:none;">
                             <h3>Fallen Logs</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-logs" autocomplete="off" type="checkbox">Item in grass at bottom of screen</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-logs" autocomplete="off" type="checkbox">? Block before cloud machine room</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-logs" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Lakilester',['Super Boots','Ultra Boots']">Item in grass at bottom of screen</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-logs" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Lakilester',['Super Boots','Ultra Boots']">? Block before cloud machine room</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-rosie" style="display:none;">
                             <h3>Rosie</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-rosie" autocomplete="off" type="checkbox">Give Rosie the Crystal Berry</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-rosie" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Blue Berry','Crystal Berry'">Give Rosie the Crystal Berry</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-blue-flower" style="display:none;">
                             <h3>Blue Flower</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-blue-flower" autocomplete="off" type="checkbox">[Coinsanity] Hidden block between brick block and spring</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-blue-flower" autocomplete="off" type="checkbox">Hidden block above brick block</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-blue-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Blue Berry'">[Coinsanity] Hidden block between brick block and spring</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-blue-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Blue Berry'">Hidden block above brick block</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-three-trees" style="display:none;">
                             <h3>Three Trees</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox">Hit trees Middle, Right, Left</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox">Second set of vines</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">Hit trees Middle, Right, Left</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">Second set of vines</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-petunia" style="display:none;">
                             <h3>Petunia</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox">[Panel] Near bottom left corner of room directly above grass</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox">2 items in tree</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox">Talk to Petunia and defeat all moles</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Near bottom left corner of room directly above grass</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">Talk to Petunia and defeat all moles</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-well" style="display:none;">
                             <h3>Well</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-well" autocomplete="off" type="checkbox">Give a blue berry to the well</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-well" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Blue Berry'">Give a blue berry to the well</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-posie" style="display:none;">
                             <h3>Posie</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-posie" autocomplete="off" type="checkbox">2 items from Posie</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-posie" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Red Berry'">2 items from Posie</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-red-flower" style="display:none;">
                             <h3>Red Flower</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox">[Panel] In front of tree</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox">2 items in tree</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox">Item in middle vines</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Red Berry'">[Panel] In front of tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Red Berry'">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Red Berry'">Item in middle vines</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-yellow-flower" style="display:none;">
                             <h3>Yellow Flower</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox">Vines next to yellow flower</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox">2 items in tree</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox">Item in grass right of tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']]">Vines next to yellow flower</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester']">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester']">Item in grass right of tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-bubble-tree" style="display:none;">
                             <h3>Bubble Berry Tree</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox">[Panel] Under hidden block on right side</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox">? Block on left side</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox">2 items in tree</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox">Hidden ? Block on right side</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Under hidden block on right side</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester']">? Block on left side</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester'],'Water Stone','Sushie'">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester']">Hidden ? Block on right side</label></li>
                             </ul>
                         </div>
                         <div id="maps-flower-fields-lily" style="display:none;">
                             <h3>Lily</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-lily" autocomplete="off" type="checkbox">Give Water Stone to Lily</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-lily" autocomplete="off" type="checkbox">Item in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-lily" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester'],'Water Stone'">Give Water Stone to Lily</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-lily" autocomplete="off" type="checkbox" data-requirements-glitchless="['chapter-6-open',['Magical Seed 1','Magical Seed 2','Magical Seed 3','Magical Seed 4']],'Yellow Berry',['Parakarry','Lakilester']">Item in tree</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -2153,78 +2153,78 @@
                         <div id="maps-shiver-region-staircase" style="display:none;">
                             <h3>Ice Staircase</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox">? Block up first set of stairs</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox">Item on ledge when falling down after second set of stairs</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone'">? Block up first set of stairs</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone'">Item on ledge when falling down after second set of stairs</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-merlar" style="display:none;">
                             <h3>Merlar's Sanctuary</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-merlar" autocomplete="off" type="checkbox">Sacred item sealed away for centuries</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-merlar" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Bombette'">Sacred item sealed away for centuries</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-tunnel" style="display:none;">
                             <h3>Shiver Mountain Tunnel</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox">Left pillar</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox">Middle pillar</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox">Right pillar</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper'">Left pillar</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper'">Middle pillar</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper'">Right pillar</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-hills" style="display:none;">
                             <h3>Shiver Mountain Hills</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-hills" autocomplete="off" type="checkbox">Item below Kooper switch</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-hills" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots']">Item below Kooper switch</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-passage" style="display:none;">
                             <h3>Shiver Mountain Passage</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-passage" autocomplete="off" type="checkbox">Ultra Boots block</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-passage" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots'">Ultra Boots block</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-west-city" style="display:none;">
                             <h3>West Shiver City</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox">[Panel] Next to the Mayor's house</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox">[Letter] Mayor Penguin</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox">Talk to Mayor after having met Merle</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox">Chest in middle house</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Next to the Mayor's house</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Mayor Penguin'">[Letter] Mayor Penguin</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Talk to Mayor after having met Merle</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-west-city" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Chest in middle house</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-center-city" style="display:none;">
                             <h3>Center Shiver City</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-center-city" autocomplete="off" type="checkbox">Item in the Inn</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-center-city" autocomplete="off" type="checkbox">5 items in the Inn after giving Scarf and Bucket to snowmen</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-center-city" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item in the Inn</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-center-city" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket'">5 items in the Inn after giving Scarf and Bucket to snowmen</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-east-city" style="display:none;">
                             <h3>East Shiver City</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-east-city" autocomplete="off" type="checkbox">Item in lake</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-east-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots'],'Sushie'">Item in lake</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-snowfield" style="display:none;">
                             <h3>Shiver Snowfield</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox">[Panel] Along bottom of room</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox">Hit left pine tree 4 times</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox">Item behind pine tree in top right corner</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Along bottom of room</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Hit left pine tree 4 times</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Item behind pine tree in top right corner</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-outside-starborn" style="display:none;">
                             <h3>Outside Starborn Valley</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-outside-starborn" autocomplete="off" type="checkbox">Item behind ice</label></li>
-                                <li><label><input data-map-group="maps-shiver-outside-starborn" autocomplete="off" type="checkbox">Hidden block where you fight Monstar</label></li>
+                                <li><label><input data-map-group="maps-shiver-outside-starborn" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Item behind ice</label></li>
+                                <li><label><input data-map-group="maps-shiver-outside-starborn" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Hidden block where you fight Monstar</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-starborn" style="display:none;">
                             <h3>Starborn Valley</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-starborn" autocomplete="off" type="checkbox">[Letter] Frost T. (Chain)</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-starborn" autocomplete="off" type="checkbox">Talk to Merle</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-starborn" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Frost T.'">[Letter] Frost T. (Chain)</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-starborn" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Talk to Merle</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -2233,69 +2233,69 @@
                         <div id="maps-crystal-palace-cave" style="display:none;">
                             <h3>Cave</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-palace-cave" autocomplete="off" type="checkbox">Item in cave</label></li>
+                                <li><label><input data-map-group="maps-crystal-palace-cave" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">Item in cave</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-panel-room" style="display:none;">
                             <h3>Ground Panel Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-panel-room" autocomplete="off" type="checkbox">? Block</label></li>
+                                <li><label><input data-map-group="maps-crystal-panel-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-shooting-star" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-shooting-star" autocomplete="off" type="checkbox">Item on ledge</label></li>
+                                <li><label><input data-map-group="maps-crystal-shooting-star" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">Item on ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-pdown" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-pdown" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-pdown" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-pup" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-pup" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-pup" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-red-key" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-red-key" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-red-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key'],'Bombette'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-blue-key" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-blue-key" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-blue-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-palace-key" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-palace-key" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-palace-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-triple-dip" style="display:none;">
                             <h3>Triple Dip</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-triple-dip" autocomplete="off" type="checkbox">Chest, blow up right wall in switch room</label></li>
+                                <li><label><input data-map-group="maps-crystal-triple-dip" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">Chest, blow up right wall in switch room</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-small-statue" style="display:none;">
                             <h3>Small Statue Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox">[Panel] Under block</label></li>
-                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox">? Block</label></li>
+                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">[Panel] Under block</label></li>
+                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots','Kooper','Star Stone','Red Key','Bombette'">? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-large-statue" style="display:none;">
                             <h3>Large Statue Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox">[Panel] Under block</label></li>
-                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox">? Block</label></li>
+                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">[Panel] Under block</label></li>
+                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots','Kooper','Star Stone','Red Key','Bombette'">? Block</label></li>
                             </ul>
                         </div>
                     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1119,6 +1119,12 @@ $(document).ready(function(){
     var section_color = localStorageGetWithDefault("section-color", "#23233b");
     $(".section").css("background-color", section_color);
     $("#section-color").val(section_color);
+
+    $("img").click(function() {getAvailableChecks($(this).attr('id').replace("'","\\\\\'"))});
+    $("img").contextmenu(function() {getAvailableChecks($(this).attr('id'))});
+    $(".star-spirit").click(function() {getAvailableChecks($('.star-spirit:not(.unselected)').length);});
+    $("[type='checkbox']").click(function() {getAvailableChecks($(this).attr('id'))});
+    getAvailableChecks();
 });
 
 function resetPage() {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -767,6 +767,9 @@ $(document).ready(function(){
         var isChecked = $(this).is(':checked');
         $(".koopa-koot-generated-item").toggle(isChecked);
         $(".koopa-koot-tracker").toggle(isChecked);
+        toggleChecks("[Koot]", !isChecked);
+        toggleChecks("[Koot] [Coinsanity]", !isChecked || !$("#coins-randomized").is(':checked'));
+        countChecks();
         localStorage.setItem("koopa-koot-randomized", isChecked);
         $("#flag-koopakoot").toggle(isChecked);
     });
@@ -1001,6 +1004,7 @@ $(document).ready(function(){
         var isChecked = $(this).is(':checked');
         localStorage.setItem("coins-randomized", isChecked);
         toggleChecks("[Coinsanity]", !isChecked);
+        toggleChecks("[Koot] [Coinsanity]", !isChecked || !$("#koopa-koot-randomized").is(':checked'));
         $("#flag-coinsanity").toggle(isChecked);
         countChecks();
     });
@@ -1178,6 +1182,8 @@ function resetPage() {
     $("#coins-randomized").click();
     $("#letters-randomized").click();
     $("#letters-randomized").click();
+    $("#koopa-koot-randomized").click();
+    $("#koopa-koot-randomized").click();
 }
 
 function savePageState() {

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -16,7 +16,7 @@ function countChecks() {
 
     $("#map-checks label").each(function() {
         if ($(this).text().includes("[Coinsanity]")) {
-            if ($("#coins-randomized").is(':checked')) {
+            if ($("#coins-randomized").is(':checked') && !$(this).hasClass('disabled')) {
                 ++coinsanity_checks;
                 ++total_checks;
             }
@@ -27,6 +27,10 @@ function countChecks() {
             }
         } else if ($(this).text().includes("[Dojo]")) {
             if ($("#dojo-randomized").is(':checked')) {
+                ++total_checks;
+            }
+        } else if ($(this).text().includes("[Koot]")) {
+            if ($("#koopa-koot-randomized").is(':checked') && !$(this).hasClass('disabled')) {
                 ++total_checks;
             }
         } else if ($(this).text().includes("[Letter]")) {

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -249,3 +249,64 @@ function synchronizeMapsKey(keyObj, current, previous) {/*
         updateSingleMapCheck(check, true);
     }*/
 }
+
+function getAvailableChecks(check) {
+    $(check ? (typeof(check) == typeof(1) ? "[data-requirements-glitchless*='" + check + "'],[data-requirements-glitchless*='" + (check - 1) + "'],[data-requirements-glitchless*='" + (check + 1) + "']" : "[data-requirements-glitchless*=\"" + check + "\"]") : "[data-requirements-glitchless]").each(function() {
+        var reqs = JSON.parse('[' + $(this).attr('data-requirements-glitchless').replaceAll("'", '"').replaceAll('\\"', "'") + ']');
+        var available = true;
+        for (var req of reqs) {
+            if (Array.isArray(req)) {
+                for (var subreq of req) {
+                    if (Array.isArray(subreq)) {
+                        for (var subsubreq of subreq) {
+                            if (typeof(subsubreq) == typeof(1)) {
+                                available = $('.star-spirit:not(.unselected)').length >= subsubreq;
+                            } else if (typeof(subsubreq) == typeof('')) {
+                                available = $("[id=\"" + subsubreq + "\"]").length && $("[id=\"" + subsubreq + "\"]:not(.unselected)").length && ($("input[id=\"" + subsubreq + "\"]:checked").length || !$("input[id=\"" + subsubreq + "\"]").length);
+                            } else {
+                                available = parseInt($("[data-chapter-key-count='" + subsubreq.chapter + "']").text().split('/')[0]) >= subsubreq.keys;
+                            }
+                            if (!available) break;
+                        }
+                    } else if (typeof(subreq) == typeof(1)) {
+                        available = $('.star-spirit:not(.unselected)').length >= subreq;
+                    } else if (typeof(subreq) == typeof('')) {
+                        available = $("[id=\"" + subreq + "\"]").length && $("[id=\"" + subreq + "\"]:not(.unselected)").length && ($("input[id=\"" + subreq + "\"]:checked").length || !$("input[id=\"" + subreq + "\"]").length);
+                    } else {
+                        available = parseInt($("[data-chapter-key-count='" + subreq.chapter + "']").text().split('/')[0]) >= subreq.keys;
+                    }
+                    if (available) break;
+                }
+            } else if (typeof(req) == typeof(1)) {
+                available = $('.star-spirit:not(.unselected)').length >= req;
+            } else if (typeof(req) == typeof('')) {
+                available = $("[id=\"" + req + "\"]").length && $("[id=\"" + req + "\"]:not(.unselected)").length && ($("input[id=\"" + req + "\"]:checked").length || !$("input[id=\"" + req + "\"]").length);
+            } else {
+                available = parseInt($("[data-chapter-key-count='" + req.chapter + "']").text().split('/')[0]) >= req.keys;
+            }
+            if (!available) break;
+        }
+        if (!available) {
+            $(this).parent().addClass('unavailable');
+        }
+        else {
+            $(this).parent().removeClass('unavailable');
+        }
+    });
+    $("[data-checks-list]").each(function() {
+        if (!$('label:has([data-map-group=' + $(this).attr('data-checks-list') + ']:not(:checked)):not(.disabled):not(.unavailable)').length) {
+            $(this).addClass('unavailable');
+        }
+        else {
+            $(this).removeClass('unavailable');
+        }
+    });
+    $("[data-map]").each(function() {
+        if (!$('[id=' + $(this).attr('data-map') + '] [data-checks-list]:not(.has-nothing):not(.complete):not(.unavailable)').length) {
+            $(this).addClass('unavailable');
+        }
+        else {
+            $(this).removeClass('unavailable');
+        }
+    });
+}

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -259,6 +259,8 @@ function getAvailableChecks(check) {
         // Arrays suggest any of their elements fulfills the same requirement
         // - Sub-arrays require all elements to fulfill the requirement
         // Objects are used for chapter keys in the format {chapter: <chapter number>, keys: <# keys>}
+        // As an example, the requirements for the Bombette check are listed as ['Kooper',[[{'chapter':1,'keys':1},'Bombette'],{'chapter':1,'keys':2}]]
+        // This means you need Kooper (to get the bridge to enter the fortress) and either 1 key and Bombette (to enter the first door and blow up the jail wall) or 2 keys (to get to the trap door)
         // The code below parses the list of requirements and determines if they are met
         var reqs = JSON.parse('[' + $(this).attr('data-requirements-glitchless').replaceAll("'", '"').replaceAll('\\"', "'") + ']');
         var available = true;

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -251,7 +251,15 @@ function synchronizeMapsKey(keyObj, current, previous) {/*
 }
 
 function getAvailableChecks(check) {
+    // Loop over map checks relating to the item updated
     $(check ? (typeof(check) == typeof(1) ? "[data-requirements-glitchless*='" + check + "'],[data-requirements-glitchless*='" + (check - 1) + "'],[data-requirements-glitchless*='" + (check + 1) + "']" : "[data-requirements-glitchless*=\"" + check + "\"]") : "[data-requirements-glitchless]").each(function() {
+        // Each check has a logical set of requirements
+        // Strings are the name of the item required
+        // Numbers are numbers of Star Spirits required
+        // Arrays suggest any of their elements fulfills the same requirement
+        // - Sub-arrays require all elements to fulfill the requirement
+        // Objects are used for chapter keys in the format {chapter: <chapter number>, keys: <# keys>}
+        // The code below parses the list of requirements and determines if they are met
         var reqs = JSON.parse('[' + $(this).attr('data-requirements-glitchless').replaceAll("'", '"').replaceAll('\\"', "'") + ']');
         var available = true;
         for (var req of reqs) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -638,6 +638,20 @@ label.disabled {
     text-decoration: line-through 5px #00000086;
 }
 
+label.unavailable {
+    color: #ffffff86;
+}
+
+table.map td.unavailable, button.unavailable {
+    background-color: #ff818167;
+    -webkit-filter: none;
+    filter: none;
+}
+
+table.map td.unavailable:hover, button.unavailable:hover {
+    background-color: #f37e11;
+}
+
 table.map {
     margin: 0 auto;
 }


### PR DESCRIPTION
This change will cause map checks to be shown in gray when they cannot be completed without glitches based on the currently collected items. Areas where no checks can be completed will be marked in red. Addresses issue #35