### PR TITLE
Hammerless and starting location logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,66 +919,66 @@
                         <div id="maps-prologue-playground" style="display:none;">
                             <h3>Playground</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Far right tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">Far right tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-outside-playground" style="display:none;">
                             <h3>Outside Playground</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right of stone block</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] 4 items above spring</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Far left ? Block</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Tree</label></li>
-                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Item on ledge above spring</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right of stone block</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer']">[Coinsanity] 4 items above spring</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">[Coinsanity] Far left ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">Tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer']">Item on ledge above spring</label></li>
                                 <li><label><input data-map-group="maps-prologue-outside-playground" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">? Block above stone block</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-outside-village" style="display:none;">
                             <h3>Outside Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-outside-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Item on ledge</label></li>
+                                <li><label><input data-map-group="maps-prologue-outside-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer']">Item on ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-village" style="display:none;">
                             <h3>Goomba Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Goompa','Parakarry'">[Letter] Goompa</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Goompapa 1','Parakarry'">[Letter] Goompapa 1 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Goompapa 2','Parakarry'">[Letter] Goompapa 2 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep'">[Koot] Talk to Goompa after Koopa Koot asks for his Tape</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],'Dolly'">Give Dolly to Goombaria</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Goombario</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Goompa</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Goompa's Veranda</label></li>
-                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Tree</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],'Goompa','Parakarry'">[Letter] Goompa</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],'Goompapa 1','Parakarry'">[Letter] Goompapa 1 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],'Goompapa 2','Parakarry'">[Letter] Goompapa 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep'">[Koot] Talk to Goompa after Koopa Koot asks for his Tape</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer']">Goombario</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],'Dolly'">Give Dolly to Goombaria</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer']">Goompa</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer']">Goompa's Veranda</label></li>
+                                <li><label><input data-map-group="maps-prologue-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-landing" style="display:none;">
                             <h3>Mario's Landing</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-landing" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of the room</label></li>
+                                <li><label><input data-map-group="maps-prologue-landing" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:GoombaVillage','Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of the room</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-road1" style="display:none;">
                             <h3>Goomba Road 1</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-road1" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-road2" style="display:none;">
                             <h3>Goomba Road 2</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">? Block</label></li>
-                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Sign</label></li>
+                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-road2" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">Sign</label></li>
                             </ul>
                         </div>
                         <div id="maps-prologue-castle" style="display:none;">
                             <h3>Goomba King's Castle</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right side of Goomba King's Fortress near tree</label></li>
-                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Hammer','Ultra Hammer']">Tree left of the fortress</label></li>
-                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox">Break brick block to spawn ? Block</label></li>
+                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:GoombaVillage','Hammer'],'Super Hammer','Ultra Hammer']">Tree left of the fortress</label></li>
+                                <li><label><input data-map-group="maps-prologue-castle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Break brick block to spawn ? Block</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1001,7 +1001,7 @@
                         <div id="maps-toad-town-mario-house" style="display:none;">
                             <h3>Mario's House</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-mario-house" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea'">[Koot] Talk to Luigi after Koopa Koot requests his autograph</label></li>
+                                <li><label><input data-map-group="maps-toad-town-mario-house" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea'">[Koot] Talk to Luigi after Koopa Koot requests his autograph</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-merluvlee" style="display:none;">
@@ -1010,7 +1010,7 @@
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of pot outside house</label></li>
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox">[Shop] 15 items from Merlow</label></li>
                                 <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="'Merlow','Parakarry'">[Letter] Merlow</label></li>
-                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Crystal Ball'">[Koot] Give Merluvlee the Crystal Ball</label></li>
+                                <li><label><input data-map-group="maps-toad-town-merluvlee" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Crystal Ball'">[Koot] Give Merluvlee the Crystal Ball</label></li>
                             </ul>
                         </div>
                         <div id="maps-toad-town-harbor" style="display:none;">
@@ -1018,7 +1018,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Outside Club 64</label></li>
                                 <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" data-requirements-glitchless="'Fishmael','Parakarry'">[Letter] Fishmael (Chain)</label></li>
-                                <li><label class="disabled"><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="5">[Trade] Give Coconut to Trading Event Toad</label></li>
+                                <li><label class="disabled"><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],5">[Trade] Give Coconut to Trading Event Toad</label></li>
                                 <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox">Talk to Simon in Club 64 (first time)</label></li>
                                 <li><label><input data-map-group="maps-toad-town-harbor" autocomplete="off" type="checkbox" data-requirements-glitchless="'Melody'">Give Melody to Simon in Club 64</label></li>
                             </ul>
@@ -1026,7 +1026,7 @@
                         <div id="maps-toad-town-outside" style="display:none;">
                             <h3>Outside Toad Town</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toad-town-outside" autocomplete="off" type="checkbox">Chest on top of Gate</label></li>
+                                <li><label><input data-map-group="maps-toad-town-outside" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Chest on top of Gate</label></li>
                                 <li><label><input data-map-group="maps-toad-town-outside" autocomplete="off" type="checkbox">? Block</label></li>
                             </ul>
                         </div>
@@ -1042,7 +1042,7 @@
                                 <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Miss T.','Parakarry'">[Letter] Miss T.</label></li>
                                 <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Russ T.','Parakarry'">[Letter] Russ T.</label></li>
                                 <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox">[Shop] 6 items in Shop</label></li>
-                                <li><label class="disabled"><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="1">[Trade] Give Koopa Leaf to Trading Event Toad</label></li>
+                                <li><label class="disabled"><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],1">[Trade] Give Koopa Leaf to Trading Event Toad</label></li>
                                 <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Dictionary'">Give Dictionary to Russ T.</label></li>
                                 <li><label><input data-map-group="maps-toad-town-gate" autocomplete="off" type="checkbox" data-requirements-glitchless="'Sushie'">Item at Sushie panel</label></li>
                             </ul>
@@ -1057,7 +1057,7 @@
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="2">[Shop] 3 items in Rowf's Shop after clearing 2 chapters</label></li>
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="3">[Shop] 3 items in Rowf's Shop after clearing 3 chapters</label></li>
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="4">[Shop] 3 items in Rowf's Shop after clearing 4 chapters</label></li>
-                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox">Tree by Merlon's house</label></li>
+                                <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Tree by Merlon's house</label></li>
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Calculator'">Give Calculator to Rowf</label></li>
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="'Mailbag'">Give Mailbag to Post Office</label></li>
                                 <li><label><input data-map-group="maps-toad-town-center" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots']">Ground Pound inside Merlon's house 3 times</label></li>
@@ -1102,13 +1102,13 @@
                         <div id="maps-sewers-bricks" style="display:none;">
                             <h3>Bricks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-bricks" autocomplete="off" type="checkbox">Hidden block next to last brick block</label></li>
+                                <li><label><input data-map-group="maps-sewers-bricks" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer']">Hidden block next to last brick block</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-shrink-stomp" style="display:none;">
                             <h3>Shrink Stomp</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-sewers-shrink-stomp" autocomplete="off" type="checkbox">Chest</label></li>
+                                <li><label><input data-map-group="maps-sewers-shrink-stomp" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-sewers-upgrade" style="display:none;">
@@ -1191,31 +1191,31 @@
                             <h3>Switch Bridge #1</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox">? Block</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Kooper item</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox">Item behind small fence</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper'">Kooper item</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Item behind small fence</label></li>
                             </ul>
                         </div>
                         <div id="maps-pleasant-path-koopa" style="display:none;">
                             <h3>Outside Koopa Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of three pillars</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox">Item behind right-most pillar</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox">Break brick boxes (left, right, middle)</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Middle of three pillars</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Item behind right-most pillar</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-koopa" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Break brick boxes (left, right, middle)</label></li>
                             </ul>
                         </div>
                         <div id="maps-pleasant-path-bridge2" style="display:none;">
                             <h3>Switch Bridge #2</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Under 5 coins / items</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox">[Coinsanity] 5 items at start of room</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Kooper','Ultra Boots']">Item on brick block</label></li>
-                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Hidden ? block after bridge</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Under 5 coins / items</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">[Coinsanity] 5 items at start of room</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],['Kooper','Ultra Boots']">Item on brick block</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-bridge2" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper'">Hidden ? block after bridge</label></li>
                             </ul>
                         </div>
                         <div id="maps-pleasant-path-fortress" style="display:none;">
                             <h3>Path to Fortress</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-pleasant-path-fortress" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Item in first tree</label></li>
+                                <li><label><input data-map-group="maps-pleasant-path-fortress" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper'">Item in first tree</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1224,60 +1224,60 @@
                         <div id="maps-koopa-village-fuzzies" style="display:none;">
                             <h3>Fuzzy Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-koopa-village-fuzzies" autocomplete="off" type="checkbox">Item Fuzzies are holding</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-fuzzies" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer']">Item Fuzzies are holding</label></li>
                             </ul>
                         </div>
                         <div id="maps-koopa-village-behind-kooper" style="display:none;">
                             <h3>Behind Kooper's House</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-koopa-village-behind-kooper" autocomplete="off" type="checkbox" data-requirements-glitchless="['Kooper','Parakarry']">On tall stump</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-behind-kooper" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],['Kooper','Parakarry']">On tall stump</label></li>
                             </ul>
                         </div>
                         <div id="maps-koopa-village-west" style="display:none;">
                             <h3>Koopa Village West</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">[Shop] 6 items in Shop</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Left of tree</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="'Mort T. (Koopa Village Inn)','Parakarry'">[Letter] Mort T.</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koover 1 (Koopa Village Entrance)','Parakarry'">[Letter] Koover 1 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koover 2 (Koopa Village Entrance)','Parakarry'">[Letter] Koover 2 (Chain)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph'">[Koot] Far right bush after Koopa Koot requests his Wallet</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta'">[Koot] Second bush from left after Koopa Koot requests his Glasses</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Bottom bush on left side</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox">Third bush from the right</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">[Shop] 6 items in Shop</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Left of tree</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Mort T. (Koopa Village Inn)','Parakarry'">[Letter] Mort T.</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Koover 1 (Koopa Village Entrance)','Parakarry'">[Letter] Koover 1 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Koover 2 (Koopa Village Entrance)','Parakarry'">[Letter] Koover 2 (Chain)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph'">[Koot] Far right bush after Koopa Koot requests his Wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta'">[Koot] Second bush from left after Koopa Koot requests his Glasses</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Bottom bush on left side</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">Third bush from the right</label></li>
                             </ul>
                         </div>
                         <div id="maps-koopa-village-east" style="display:none;">
                             <h3>Koopa Village East</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kolorado','Parakarry'">[Letter] Kolorado</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">[Koot] Talk to Kolorado's wife after starting Koopa Koot's first favor</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koopa Legends'">[Koot] [Coinsanity] Return Koopa Legends to Koopa Koot</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koopa Legends','Sleepy Sheep'">[Koot] [Coinsanity] Give Koopa Koot a Sleepy Sheep (first item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Koopa Legends','Sleepy Sheep'">[Koot] Give Koopa Koot a Sleepy Sheep (second item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape'">[Koot] [Coinsanity] Return Koopa Koot's Tape</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea'">[Koot] Give Koopa Koot Koopa Tea</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph'">[Koot] [Coinsanity] Give Luigi's Autograph to Koopa Koot</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet'">[Koot] [Coinsanity] Return Koopa Koot's wallet</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic'">[Koot] [Coinsanity] Give Koopa Koot a Tasty Tonic</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph'">[Koot] Give Merluvlee's Autograph to Koopa Koot</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph'">[Koot] [Coinsanity] Talk to Koopa Koot after reading the news in Toad Town</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom'">[Koot] [Coinsanity] Give Koopa Koot a Life Shroom (first item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom'">[Koot] Give Koopa Koot a Life Shroom (second item)</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake'">[Koot] [Coinsanity] Give Koopa Koot a Nutty Cake</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette'">[Koot] Talk to Koopa Koot after calming the Bob-ombs</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo'">[Koot] [Coinsanity] Give Koopa Koot the Old Photo</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta'">[Koot] [Coinsanity] Give Koopa Koot Koopasta</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses'">[Koot] [Coinsanity] Return Koopa Koot's glasses</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime'">[Koot] Give Koopa Koot a Lime</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie'">[Koot] [Coinsanity] Give Koopa Koot a Kooky Cookie</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package'">[Koot] [Coinsanity] Give Koopa Koot his package</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut'">[Koot] [Coinsanity] Give Koopa Koot a Coconut</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut','Red Jar'">[Koot] Give Koopa Koot the Red Jar</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">First bush on left</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper\'s Shell'">Give Kooper his shell</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer']">[Koot] Talk to Kolorado's wife after starting Koopa Koot's first favor</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],'Koopa Legends'">[Koot] [Coinsanity] Return Koopa Legends to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],'Koopa Legends','Sleepy Sheep'">[Koot] [Coinsanity] Give Koopa Koot a Sleepy Sheep (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],'Koopa Legends','Sleepy Sheep'">[Koot] Give Koopa Koot a Sleepy Sheep (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep','Tape'">[Koot] [Coinsanity] Return Koopa Koot's Tape</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea'">[Koot] Give Koopa Koot Koopa Tea</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],1,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph'">[Koot] [Coinsanity] Give Luigi's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet'">[Koot] [Coinsanity] Return Koopa Koot's wallet</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic'">[Koot] [Coinsanity] Give Koopa Koot a Tasty Tonic</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph'">[Koot] Give Merluvlee's Autograph to Koopa Koot</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph'">[Koot] [Coinsanity] Talk to Koopa Koot after reading the news in Toad Town</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom'">[Koot] [Coinsanity] Give Koopa Koot a Life Shroom (first item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom'">[Koot] Give Koopa Koot a Life Shroom (second item)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],3,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake'">[Koot] [Coinsanity] Give Koopa Koot a Nutty Cake</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette'">[Koot] Talk to Koopa Koot after calming the Bob-ombs</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo'">[Koot] [Coinsanity] Give Koopa Koot the Old Photo</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta'">[Koot] [Coinsanity] Give Koopa Koot Koopasta</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses'">[Koot] [Coinsanity] Return Koopa Koot's glasses</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime'">[Koot] Give Koopa Koot a Lime</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie'">[Koot] [Coinsanity] Give Koopa Koot a Kooky Cookie</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package'">[Koot] [Coinsanity] Give Koopa Koot his package</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut'">[Koot] [Coinsanity] Give Koopa Koot a Coconut</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut','Red Jar'">[Koot] Give Koopa Koot the Red Jar</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette']">First bush on left</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper\'s Shell'">Give Kooper his shell</label></li>
                                 <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="'Artifact',['Mamar',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Give Artifact to Kolorado</label></li>
-                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox">Item on top of brick block on right (after defeating fuzzies)</label></li>
+                                <li><label><input data-map-group="maps-koopa-village-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer']">Item on top of brick block on right (after defeating fuzzies)</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1286,8 +1286,8 @@
                         <div id="maps-kbf-entrance" style="display:none;">
                             <h3>Entrance</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper'">Defeat Koopa by first locked door</label></li>
-                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',{'chapter':1,'keys':4}">Top of room guarded by Bob-omb</label></li>
+                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper'">Defeat Koopa by first locked door</label></li>
+                                <li><label><input data-map-group="maps-kbf-entrance" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper',{'chapter':1,'keys':4}">Top of room guarded by Bob-omb</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-cannons" style="display:none;">
@@ -1300,7 +1300,7 @@
                             <h3>Kooper Puzzle Room</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette',{'chapter':1,'keys':3}">Left Jail Cell</label></li>
-                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',{'chapter':1,'keys':1}">Middle Jail Cell</label></li>
+                                <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper',{'chapter':1,'keys':1}">Middle Jail Cell</label></li>
                                 <li><label><input data-map-group="maps-kbf-puzzle-room" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper','Bombette',{'chapter':1,'keys':1}">Right Jail Cell</label></li>
                             </ul>
                         </div>
@@ -1319,13 +1319,13 @@
                         <div id="maps-kbf-firebars" style="display:none;">
                             <h3>Firebars</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-firebars" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',{'chapter':1,'keys':1}">Item at end of room</label></li>
+                                <li><label><input data-map-group="maps-kbf-firebars" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper',{'chapter':1,'keys':1}">Item at end of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-kbf-jail" style="display:none;">
                             <h3>Jail</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-kbf-jail" autocomplete="off" type="checkbox" data-requirements-glitchless="'Kooper',[[{'chapter':1,'keys':1},'Bombette'],{'chapter':1,'keys':2}]">Bombette</label></li>
+                                <li><label><input data-map-group="maps-kbf-jail" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer','Bombette'],'Kooper',[[{'chapter':1,'keys':1},'Bombette'],{'chapter':1,'keys':2}]">Bombette</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1334,50 +1334,50 @@
                         <div id="maps-mt-rugged-letter3" style="display:none;">
                             <h3>Letter 3</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block left after taking spring</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">[Coinsanity] Circle of items across Parakarry gap</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] 2 items on ground below Parakarry gap</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">? Block by Cleft when entering room</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Chest in cave</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Item across Parakarry gap</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">? Block past Cleft after spring</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item on far right ledge</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:DryDryOutpost','Hammer'],['starting-location:DryDryOutpost','Kooper'],'Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block left after taking spring</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">[Coinsanity] Circle of items across Parakarry gap</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] 2 items on ground below Parakarry gap</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">? Block by Cleft when entering room</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">Chest in cave</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Item across Parakarry gap</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:DryDryOutpost','Hammer'],['starting-location:DryDryOutpost','Kooper'],'Bombette','Super Hammer','Ultra Hammer']">? Block past Cleft after spring</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">Item on far right ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-letter1" style="display:none;">
                             <h3>Letter 1</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By wall near end of slide</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],['Kooper','Parakarry']">Item on first ledge</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Item on second ledge</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By wall near end of slide</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],['Kooper','Parakarry']">Item on first ledge</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-letter1" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Item on second ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-seed" style="display:none;">
                             <h3>Seed Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Bub-ulb</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item on support beam when falling through opening at the top</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Parakarry'">Bub-ulb</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-seed" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">Item on support beam when falling through opening at the top</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-buzzar" style="display:none;">
                             <h3>Buzzar</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-buzzar" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item on ground by Cleft</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-buzzar" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">Item on ground by Cleft</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-train" style="display:none;">
                             <h3>Train Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Item in top most bush</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Give three letters to Parakarry</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">Item in top most bush</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-train" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">Give three letters to Parakarry</label></li>
                             </ul>
                         </div>
                         <div id="maps-mt-rugged-whacka" style="display:none;">
                             <h3>Whacka</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] Three items on slide</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">Hit Whacka</label></li>
-                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bombette','Super Hammer','Ultra Hammer']">? Block</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">[Coinsanity] Three items on slide</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="[['starting-location:DryDryOutpost','Hammer'],['Bombette','Hammer'],'Super Hammer','Ultra Hammer']">Hit Whacka</label></li>
+                                <li><label><input data-map-group="maps-mt-rugged-whacka" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer']">? Block</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1386,145 +1386,145 @@
                         <div id="maps-desert-top-left" style="display:none;">
                             <h3>Two ? Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-top-left" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Left ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-ruins" style="display:none;">
                             <h3>Dry Dry Ruins</h3>
                             <ul>
-                                <li><label class="disabled"><input data-map-group="maps-desert-ruins" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="3">[Trade] Give Nutty Cake to Trading Event Toad</label></li>
+                                <li><label class="disabled"><input data-map-group="maps-desert-ruins" autocomplete="off" type="checkbox" disabled data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],3">[Trade] Give Nutty Cake to Trading Event Toad</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-pokey" style="display:none;">
                             <h3>Pokey Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-pokey" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Behind cactus at top of room</label></li>
+                                <li><label><input data-map-group="maps-desert-pokey" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Behind cactus at top of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-thunder-rage" style="display:none;">
                             <h3>Thunder Rage</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-thunder-rage" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block above rock on right side</label></li>
+                                <li><label><input data-map-group="maps-desert-thunder-rage" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block above rock on right side</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-above-runaway-pay" style="display:none;">
                             <h3>Two ? Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-above-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Right ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-hammer-block" style="display:none;">
                             <h3>Hammer Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hammer yellow block once</label></li>
-                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hammer yellow block five times</label></li>
-                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hammer yellow block ten times</label></li>
+                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Hammer yellow block once</label></li>
+                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Hammer yellow block five times</label></li>
+                                <li><label><input data-map-group="maps-desert-hammer-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Hammer yellow block ten times</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-five-block" style="display:none;">
                             <h3>Five ? Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Top-Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Top-Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Bottom-Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] Bottom-Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Center ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] Top-Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] Top-Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] Bottom-Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] Bottom-Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-five-block" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">Center ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-runaway-pay" style="display:none;">
                             <h3>Runaway Pay</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block in the middle of three trees</label></li>
+                                <li><label><input data-map-group="maps-desert-runaway-pay" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block in the middle of three trees</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-camp" style="display:none;">
                             <h3>Kolorado's Camp</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-camp" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Mamar'">Tree at camp location after saving Mamar</label></li>
+                                <li><label><input data-map-group="maps-desert-camp" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Mamar',['Hammer','Super Hammer','Ultra Hammer','Bombette']">Tree at camp location after saving Mamar</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-stone-cactus" style="display:none;">
                             <h3>Stone Cactus</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-stone-cactus" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Below stone cactus</label></li>
+                                <li><label><input data-map-group="maps-desert-stone-cactus" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Below stone cactus</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-nomadimouse" style="display:none;">
                             <h3>Nomadimouse</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-nomadimouse" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Nomadimouse','Parakarry'">[Letter] Nomadimouse</label></li>
+                                <li><label><input data-map-group="maps-desert-nomadimouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Nomadimouse','Parakarry'">[Letter] Nomadimouse</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-outside-outpost" style="display:none;">
                             <h3>Outside Outpost</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-outside-outpost" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Far right tree</label></li>
+                                <li><label><input data-map-group="maps-desert-outside-outpost" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Far right tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-outpost-west" style="display:none;">
                             <h3>Dry Dry Outpost West</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Shop] 3 randomized items in Shop (password items are guaranteed vanilla)</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Dry Dry Shop','Parakarry'">[Letter] Shop (Chain)</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],6,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie','Package','Coconut'">[Koot] Buy Dusty Hammer, Dried Pasta, Dusty Hammer, Dried Shroom after Koopa Koot requests Red Jar</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Lyrics'">Turn in Lyrics at far right house</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Shop] 3 randomized items in Shop (password items are guaranteed vanilla)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Dry Dry Shop','Parakarry'">[Letter] Shop (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Koot] Buy Dusty Hammer, Dried Pasta, Dusty Hammer, Dried Shroom</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-west" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Lyrics'">Turn in Lyrics at far right house</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-outpost-east" style="display:none;">
                             <h3>Dry Dry Outpost East</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] On rooftops</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Mr. E','Parakarry'">[Letter] Mr. E (Chain)</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic'">[Koot] Talk to Merlee after Merluvlee requests Crystal Ball</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item on rooftops</label></li>
-                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Talk to Moustafa after buying Dried Shroom + Dusty Hammer</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] On rooftops</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Mr. E','Parakarry'">[Letter] Mr. E (Chain)</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer'],2,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic'">[Koot] Talk to Merlee after Merluvlee requests Crystal Ball</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item on rooftops</label></li>
+                                <li><label><input data-map-group="maps-desert-outpost-east" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Talk to Moustafa after buying Dried Shroom + Dusty Hammer</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-below-cactus" style="display:none;">
                             <h3>? Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-below-cactus" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] ? Block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-below-cactus" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] ? Block in middle of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-bump-attack" style="display:none;">
                             <h3>Spin Attack</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item on ledge (take Tweester in room down left from here)</label></li>
-                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Kooper','Ultra Boots']">Item on brick block, requires Kooper or Ultra Boots</label></li>
+                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item on ledge (take Tweester in room down left from here)</label></li>
+                                <li><label><input data-map-group="maps-desert-bump-attack" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Kooper','Ultra Boots']">Item on brick block, requires Kooper or Ultra Boots</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-life-shroom" style="display:none;">
                             <h3>Life Shroom</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] ? Block in middle of room</label></li>
-                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block directly above other ? Block</label></li>
+                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] ? Block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-life-shroom" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block directly above other ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-before-oasis" style="display:none;">
                             <h3>Before Oasis</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-before-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item behind bush on right side of room</label></li>
+                                <li><label><input data-map-group="maps-desert-before-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Item behind bush on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-oasis" style="display:none;">
                             <h3>Oasis</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Lemon Tree</label></li>
-                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Lime Tree</label></li>
+                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Lemon Tree</label></li>
+                                <li><label><input data-map-group="maps-desert-oasis" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Lime Tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-fxc" style="display:none;">
                             <h3>Attack FX C</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-fxc" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-fxc" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">Hidden block in middle of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-desert-opposite-fxc" style="display:none;">
                             <h3>? Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-opposite-fxc" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer']">[Coinsanity] ? Block in middle of room</label></li>
+                                <li><label><input data-map-group="maps-desert-opposite-fxc" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots','Bombette','Kooper']">[Coinsanity] ? Block in middle of room</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1533,7 +1533,7 @@
                         <div id="maps-ruins-pokey-hall" style="display:none;">
                             <h3>Pokey Hall</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-pokey-hall" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone'">Inside middle coffin</label></li>
+                                <li><label><input data-map-group="maps-ruins-pokey-hall" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone'">Inside middle coffin</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-sand-switch-2" style="display:none;">
@@ -1545,7 +1545,7 @@
                         <div id="maps-ruins-sand-room1" style="display:none;">
                             <h3>Sand Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-sand-room1" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':1}">Item on elevated platform</label></li>
+                                <li><label><input data-map-group="maps-ruins-sand-room1" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':1}">Item on elevated platform</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-key-room1" style="display:none;">
@@ -1557,15 +1557,15 @@
                         <div id="maps-ruins-super-hammer" style="display:none;">
                             <h3>Super Hammer Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-super-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Item in chest behind wall on ledge above Super Hammer chest</label></li>
-                                <li><label><input data-map-group="maps-ruins-super-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Super Hammer chest</label></li>
+                                <li><label><input data-map-group="maps-ruins-super-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Item in chest behind wall on ledge above Super Hammer chest</label></li>
+                                <li><label><input data-map-group="maps-ruins-super-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost','Bombette','Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Super Hammer chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-pokey-room" style="display:none;">
                             <h3>Pokey Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':2}">Defeat all three Pokey's after hitting ? Block</label></li>
-                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">On ledge behind hammer block</label></li>
+                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':2}">Defeat all three Pokey's after hitting ? Block</label></li>
+                                <li><label><input data-map-group="maps-ruins-pokey-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">On ledge behind hammer block</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-chomp-room-1" style="display:none;">
@@ -1577,19 +1577,19 @@
                         <div id="maps-ruins-chomp-room-2" style="display:none;">
                             <h3>Chomp Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-chomp-room-2" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Item on pedestal</label></li>
+                                <li><label><input data-map-group="maps-ruins-chomp-room-2" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':3}">Item on pedestal</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-chomp-room-3" style="display:none;">
                             <h3>Chomp Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-chomp-room-3" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':4}">Item on pedestal</label></li>
+                                <li><label><input data-map-group="maps-ruins-chomp-room-3" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone','Parakarry',{'chapter':2,'keys':4}">Item on pedestal</label></li>
                             </ul>
                         </div>
                         <div id="maps-ruins-wall-stairs" style="display:none;">
                             <h3>Wall Stairs</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-ruins-wall-stairs" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':3}">Item on ledge, reachable by breaking block and hitting switch</label></li>
+                                <li><label><input data-map-group="maps-ruins-wall-stairs" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],'Pulse Stone',{'chapter':2,'keys':3}">Item on ledge, reachable by breaking block and hitting switch</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1633,7 +1633,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] By couch</label></li>
                                 <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="'Franky (Boo\'s Mansion Entrance)','Boo\'s Portrait','Parakarry'">[Letter] Franky (Chain)</label></li>
-                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette'">[Koot] Talk to Franky after Koopa Koot requests the Old Photo</label></li>
+                                <li><label><input data-map-group="maps-boo-mansion-main" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],4,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette'">[Koot] Talk to Franky after Koopa Koot requests the Old Photo</label></li>
                             </ul>
                         </div>
                         <div id="maps-boo-mansion-record" style="display:none;">
@@ -1704,7 +1704,7 @@
                             <h3>Village 1</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait'">[Coinsanity] Block in far right house</label></li>
-                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox" data-requirements-glitchless="'Boo\'s Portrait',5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie'">[Koot] Talk to Boo near Save Block after Koopa Koot requests a Package</label></li>
+                                <li><label><input data-map-group="maps-gusty-gulch-village1" autocomplete="off" type="checkbox" data-requirements-glitchless="['Hammer','Super Hammer','Ultra Hammer'],'Boo\'s Portrait',5,'Koopa Legends','Sleepy Sheep','Tape','Koopa Tea','Luigi\'s Autograph','Wallet','Tasty Tonic','Merluvlee\'s Autograph','Life Shroom','Nutty Cake','Eldstar','Bombette','Old Photo','Koopasta','Glasses','Lime','Kooky Cookie'">[Koot] Talk to Boo near Save Block after Koopa Koot requests a Package</label></li>
                             </ul>
                         </div>
                         <div id="maps-gusty-gulch-1" style="display:none;">
@@ -1806,15 +1806,15 @@
                         <div id="maps-toybox-block-city" style="display:none;">
                             <h3>Block City</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] 3 items on left spring</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] 5 items on elevated spring</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] ? Block on left side of wall</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">[Coinsanity] ? Block on right side of wall that can be jumped across</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Item behind fallen blocks</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Parakarry'">Item on roof of left house</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">? Block on platform</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Item that Kammy spawns</label></li>
-                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open']">Chest</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">[Coinsanity] 3 items on left spring</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">[Coinsanity] 5 items on elevated spring</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">[Coinsanity] ? Block on left side of wall</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">[Coinsanity] ? Block on right side of wall that can be jumped across</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Item behind fallen blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots'],'Parakarry'">Item on roof of left house</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">? Block on platform</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Item that Kammy spawns</label></li>
+                                <li><label><input data-map-group="maps-toybox-block-city" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-gourmet-guy" style="display:none;">
@@ -1846,11 +1846,11 @@
                         <div id="maps-toybox-playhouse" style="display:none;">
                             <h3>Playhouse</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">[Coinsanity] ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest on wall</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest after door</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Item that Kammy spawns</label></li>
-                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train'">Chest at end of room</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train',['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">[Coinsanity] ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train',['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Chest on wall</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train',['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Chest after door</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train',['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Item that Kammy spawns</label></li>
+                                <li><label><input data-map-group="maps-toybox-playhouse" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train',['Hammer','Super Hammer','Ultra Hammer','Super Boots','Ultra Boots']">Chest at end of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-green-station" style="display:none;">
@@ -1875,32 +1875,32 @@
                         <div id="maps-toybox-lantern-ghost" style="display:none;">
                             <h3>Lantern Ghost</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-lantern-ghost" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Watt</label></li>
+                                <li><label><input data-map-group="maps-toybox-lantern-ghost" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">Watt</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-moving-platforms" style="display:none;">
                             <h3>Moving Platforms</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">[Coinsanity] Right ? Block</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block by first elevator</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block between two other ? blocks</label></li>
-                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block by door to Lantern Ghost room</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">Hidden block by first elevator</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">Hidden block between two other ? blocks</label></li>
+                                <li><label><input data-map-group="maps-toybox-moving-platforms" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">Hidden block by door to Lantern Ghost room</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-red-station" style="display:none;">
                             <h3>Red Station</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of station</label></li>
-                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake'">Hidden block on left side</label></li>
+                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of station</label></li>
+                                <li><label><input data-map-group="maps-toybox-red-station" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake',['Hammer','Super Hammer','Ultra Hammer']">Hidden block on left side</label></li>
                             </ul>
                         </div>
                         <div id="maps-toybox-barricade" style="display:none;">
                             <h3>Shy Guy Barricade</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette'">[Coinsanity] ? Block just past barricade</label></li>
-                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette',['Kooper','Ultra Boots']">Item on top of brick block</label></li>
-                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette'">? Block at end of room</label></li>
+                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block just past barricade</label></li>
+                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette',['Hammer','Super Hammer','Ultra Hammer'],['Kooper','Ultra Boots']">Item on top of brick block</label></li>
+                                <li><label><input data-map-group="maps-toybox-barricade" autocomplete="off" type="checkbox" data-requirements-glitchless="['Bow','toybox-open'],'Toy Train','Cake','Bombette',['Hammer','Super Hammer','Ultra Hammer']">? Block at end of room</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -1909,122 +1909,122 @@
                         <div id="maps-yoshi-ambush-room" style="display:none;">
                             <h3>Ambush Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-ambush-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Near middle of room</label></li>
+                                <li><label><input data-map-group="maps-yoshi-ambush-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Super Boots','Ultra Boots','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer']">[Panel] Near middle of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-raph" style="display:none;">
                             <h3>Raph's Tree</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Item on the outside Raph's Tree</label></li>
-                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Talk to Raphael at the top</label></li>
+                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Item on the outside Raph's Tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-raph" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Talk to Raphael at the top</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-vine-room" style="display:none;">
                             <h3>Vine Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Second Tree vine</label></li>
-                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Last Tree vine</label></li>
+                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Second Tree vine</label></li>
+                                <li><label><input data-map-group="maps-yoshi-vine-room" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Last Tree vine</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-block-puzzle" style="display:none;">
                             <h3>Block Puzzle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-block-puzzle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Hidden block near first push block</label></li>
+                                <li><label><input data-map-group="maps-yoshi-block-puzzle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Hidden block near first push block</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-deep-jungle" style="display:none;">
                             <h3>Deep Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Hidden block near bell plant</label></li>
-                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Tree vine near bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Hidden block near bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-deep-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Tree vine near bell plant</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-lightblue-yoshi" style="display:none;">
                             <h3>Light-Blue Yoshi</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-lightblue-yoshi" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item under water</label></li>
+                                <li><label><input data-map-group="maps-yoshi-lightblue-yoshi" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item under water</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-nw-jungle" style="display:none;">
                             <h3>NW Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-nw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item in tree by right side exit</label></li>
+                                <li><label><input data-map-group="maps-yoshi-nw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie',['Hammer','Super Hammer','Ultra Hammer','Bombette']">Item in tree by right side exit</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-ne-jungle" style="display:none;">
                             <h3>NE Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-ne-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">[Coinsanity] Item under water on right side of room</label></li>
+                                <li><label><input data-map-group="maps-yoshi-ne-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] Item under water on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-whale" style="display:none;">
                             <h3>Whale</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] 2 items on spinning flower</label></li>
-                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree</label></li>
-                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item behind bush near top of screen</label></li>
+                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] 2 items on spinning flower</label></li>
+                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-whale" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item behind bush near top of screen</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-sw-jungle" style="display:none;">
                             <h3>SW Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">[Coinsanity] Three items under water</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Hidden block near exit to NW Jungle</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">[Coinsanity] Three items under water</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sw-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Hidden block near exit to NW Jungle</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-se-jungle" style="display:none;">
                             <h3>SE Jungle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-se-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">? Block on island</label></li>
+                                <li><label><input data-map-group="maps-yoshi-se-jungle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">? Block on island</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-sushie" style="display:none;">
                             <h3>Sushie Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Sushie</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item on top right island</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item in tree on top right island</label></li>
-                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Misstar'">Chest after saving Misstar</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Sushie</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item on top right island</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie'">Item in tree on top right island</label></li>
+                                <li><label><input data-map-group="maps-yoshi-sushie" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Misstar'">Chest after saving Misstar</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-beach" style="display:none;">
                             <h3>Beach</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] 2 items on spinning flower</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 1 (far left)</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 2</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Hidden block by bell plant</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 3</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item on rock formation</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 4</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Hidden block by bell plant</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 5</label></li>
-                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree 6 (last tree, 2 items)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Coinsanity] 2 items on spinning flower</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree 1 (far left)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree 2</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Hidden block by bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree 3</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item on rock formation</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree 4</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Hidden block by bell plant</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree 5</label></li>
+                                <li><label><input data-map-group="maps-yoshi-beach" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree 6 (last tree, 2 items)</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-west-village" style="display:none;">
                             <h3>West Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of raven statue</label></li>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie'">Talk to Yoshi Chief after saving all the kids</label></li>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Left Coconut tree</label></li>
-                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Right Coconut tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of raven statue</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie',['Hammer','Super Hammer','Ultra Hammer']">Talk to Yoshi Chief after saving all the kids</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Left Coconut tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-west-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Right Coconut tree</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-east-village" style="display:none;">
                             <h3>East Village</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Shop] 6 items in Shop</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Red Yoshi Kid','Parakarry'">[Letter] Red Yoshi Kid (Chain)</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie'">Give a Tayce T. item to Yellow Adult Yoshi</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie','Volcano Vase','Misstar'">Give the volcano vase to Kolorado</label></li>
-                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Coconut tree on right side of room</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">[Shop] 6 items in Shop</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Red Yoshi Kid','Parakarry'">[Letter] Red Yoshi Kid (Chain)</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie',['Hammer','Super Hammer','Ultra Hammer']">Give a Tayce T. item to Yellow Adult Yoshi</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="'Watt','Sushie','Volcano Vase','Misstar',['Hammer','Super Hammer','Ultra Hammer']">Give the volcano vase to Kolorado</label></li>
+                                <li><label><input data-map-group="maps-yoshi-east-village" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],['Hammer','Super Hammer','Ultra Hammer','Bombette']">Coconut tree on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-yoshi-volcano" style="display:none;">
                             <h3>Outside Volcano</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-yoshi-volcano" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item behind large tree</label></li>
+                                <li><label><input data-map-group="maps-yoshi-volcano" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage',['Watt','Hammer'],['Watt','Super Hammer'],['Watt','Ultra Hammer'],['Watt','Super Boots'],['Watt','Ultra Boots'],'whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']]">Item behind large tree</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -2033,49 +2033,49 @@
                         <div id="maps-lavalav-hub" style="display:none;">
                             <h3>Hub Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 1</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 2</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 3</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">[Coinsanity] ? Block 4</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Kooper','Ultra Boots']">Item on top of brick block</label></li>
-                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Item on platform halfway down second zip line</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block 1</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block 2</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block 3</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">[Coinsanity] ? Block 4</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Kooper','Ultra Boots']">Item on top of brick block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-hub" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Item on platform halfway down second zip line</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-zipline" style="display:none;">
                             <h3>Zipline</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-zipline" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right side of lower level</label></li>
+                                <li><label><input data-map-group="maps-lavalav-zipline" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Right side of lower level</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-save" style="display:none;">
                             <h3>Save Block</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-save" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Left of heart block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-save" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Left of heart block</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-deadend" style="display:none;">
                             <h3>Deadend</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Left ? Block</label></li>
-                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Right ? Block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Parakarry','Lakilester']">Left ? Block</label></li>
+                                <li><label><input data-map-group="maps-lavalav-deadend" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Parakarry','Lakilester']">Right ? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-lava-puzzle" style="display:none;">
                             <h3>Lava Puzzle</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-lava-puzzle" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven'">Hidden block on right side of room</label></li>
+                                <li><label><input data-map-group="maps-lavalav-lava-puzzle" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer']">Hidden block on right side of room</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-ultra-hammer" style="display:none;">
                             <h3>Ultra Hammer Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-ultra-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Ultra Hammer chest</label></li>
+                                <li><label><input data-map-group="maps-lavalav-ultra-hammer" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Parakarry','Lakilester']">Ultra Hammer chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-lavalav-dizzy" style="display:none;">
                             <h3>Dizzy Stomp</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-lavalav-dizzy" autocomplete="off" type="checkbox" data-requirements-glitchless="['Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Parakarry','Lakilester']">Chest</label></li>
+                                <li><label><input data-map-group="maps-lavalav-dizzy" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:YoshiVillage','Watt','whale-open',['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Sushie','Jade Raven',['Hammer','Super Hammer','Ultra Hammer'],['Parakarry','Lakilester']">Chest</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------
@@ -2132,7 +2132,7 @@
                         <div id="maps-flower-fields-three-trees" style="display:none;">
                             <h3>Three Trees</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry'">Hit trees Middle, Right, Left</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry',['Hammer','Super Hammer','Ultra Hammer','Bombette']">Hit trees Middle, Right, Left</label></li>
                                 <li><label><input data-map-group="maps-flower-fields-three-trees" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry'">Second set of vines</label></li>
                             </ul>
                         </div>
@@ -2140,7 +2140,7 @@
                             <h3>Petunia</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Near bottom left corner of room directly above grass</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry'">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry',['Hammer','Super Hammer','Ultra Hammer','Bombette']">2 items in tree</label></li>
                                 <li><label><input data-map-group="maps-flower-fields-petunia" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry'">Talk to Petunia and defeat all moles</label></li>
                             </ul>
                         </div>
@@ -2160,7 +2160,7 @@
                             <h3>Red Flower</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Red Berry',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] In front of tree</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Red Berry'">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Red Berry',['Hammer','Super Hammer','Ultra Hammer','Bombette']">2 items in tree</label></li>
                                 <li><label><input data-map-group="maps-flower-fields-red-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Red Berry'">Item in middle vines</label></li>
                             </ul>
                         </div>
@@ -2168,7 +2168,7 @@
                             <h3>Yellow Flower</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry'">Vines next to yellow flower</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester']">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">2 items in tree</label></li>
                                 <li><label><input data-map-group="maps-flower-fields-yellow-flower" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester']">Item in grass right of tree</label></li>
                             </ul>
                         </div>
@@ -2177,7 +2177,7 @@
                             <ul>
                                 <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester'],['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Under hidden block on right side</label></li>
                                 <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester']">? Block on left side</label></li>
-                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester'],'Water Stone','Sushie'">2 items in tree</label></li>
+                                <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester'],'Water Stone','Sushie',['Hammer','Super Hammer','Ultra Hammer','Bombette']">2 items in tree</label></li>
                                 <li><label><input data-map-group="maps-flower-fields-bubble-tree" autocomplete="off" type="checkbox" data-requirements-glitchless="'chapter-6-entry','Yellow Berry',['Parakarry','Lakilester']">Hidden ? Block on right side</label></li>
                             </ul>
                         </div>
@@ -2194,22 +2194,22 @@
                         <div id="maps-shiver-region-staircase" style="display:none;">
                             <h3>Ice Staircase</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone'">? Block up first set of stairs</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone'">Item on ledge when falling down after second set of stairs</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone'">? Block up first set of stairs</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-staircase" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone'">Item on ledge when falling down after second set of stairs</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-merlar" style="display:none;">
                             <h3>Merlar's Sanctuary</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-merlar" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Bombette'">Sacred item sealed away for centuries</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-merlar" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Bombette'">Sacred item sealed away for centuries</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-tunnel" style="display:none;">
                             <h3>Shiver Mountain Tunnel</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper'">Left pillar</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper'">Middle pillar</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper'">Right pillar</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer']">Left pillar</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer']">Middle pillar</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-tunnel" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer']">Right pillar</label></li>
                             </ul>
                         </div>
                         <div id="maps-shiver-region-hills" style="display:none;">
@@ -2251,7 +2251,7 @@
                             <h3>Shiver Snowfield</h3>
                             <ul>
                                 <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key',['Super Boots','Ultra Boots','Ultra Hammer']">[Panel] Along bottom of room</label></li>
-                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Hit left pine tree 4 times</label></li>
+                                <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key',['Hammer','Super Hammer','Ultra Hammer']">Hit left pine tree 4 times</label></li>
                                 <li><label><input data-map-group="maps-shiver-region-snowfield" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key'">Item behind pine tree in top right corner</label></li>
                             </ul>
                         </div>
@@ -2275,69 +2275,69 @@
                         <div id="maps-crystal-palace-cave" style="display:none;">
                             <h3>Cave</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-palace-cave" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">Item in cave</label></li>
+                                <li><label><input data-map-group="maps-crystal-palace-cave" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone',['Red Key','Blue Key']">Item in cave</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-panel-room" style="display:none;">
                             <h3>Ground Panel Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-panel-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">? Block</label></li>
+                                <li><label><input data-map-group="maps-crystal-panel-room" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone',['Red Key','Blue Key']">? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-shooting-star" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-shooting-star" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">Item on ledge</label></li>
+                                <li><label><input data-map-group="maps-crystal-shooting-star" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone',['Red Key','Blue Key']">Item on ledge</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-pdown" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-pdown" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key']">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-pdown" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone',['Red Key','Blue Key']">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-pup" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-pup" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-pup" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-red-key" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-red-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone',['Red Key','Blue Key'],'Bombette'">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-red-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone',['Red Key','Blue Key'],'Bombette'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-blue-key" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-blue-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone'">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-blue-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-palace-key" style="display:none;">
                             <h3>Item Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-palace-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">Chest</label></li>
+                                <li><label><input data-map-group="maps-crystal-palace-key" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">Chest</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-triple-dip" style="display:none;">
                             <h3>Triple Dip</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-triple-dip" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">Chest, blow up right wall in switch room</label></li>
+                                <li><label><input data-map-group="maps-crystal-triple-dip" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">Chest, blow up right wall in switch room</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-small-statue" style="display:none;">
                             <h3>Small Statue Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">[Panel] Under block</label></li>
-                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots','Kooper','Star Stone','Red Key','Bombette'">? Block</label></li>
+                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">[Panel] Under block</label></li>
+                                <li><label><input data-map-group="maps-crystal-small-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots','Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">? Block</label></li>
                             </ul>
                         </div>
                         <div id="maps-crystal-large-statue" style="display:none;">
                             <h3>Large Statue Room</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper','Star Stone','Red Key','Bombette'">[Panel] Under block</label></li>
-                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots','Kooper','Star Stone','Red Key','Bombette'">? Block</label></li>
+                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket',['Super Boots','Ultra Boots'],'Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">[Panel] Under block</label></li>
+                                <li><label><input data-map-group="maps-crystal-large-statue" autocomplete="off" type="checkbox" data-requirements-glitchless="[['Super Boots','Sushie'],['Ultra Boots','Sushie'],['Odd Key','Bombette'],['blue-house-open','Bombette']],'Warehouse Key','Scarf','Bucket','Ultra Boots','Kooper',['Hammer','Super Hammer','Ultra Hammer'],'Star Stone','Red Key','Bombette'">? Block</label></li>
                             </ul>
                         </div>
                     </div>
@@ -2834,6 +2834,18 @@
                             <div class="checkbox-groove"></div>
                             <label class="checkbox-slider" for="blue-house-open"></label>
                         </div>
+                    </td>
+                </tr>
+                <tr class="seed-setting">
+                    <td class="option-name sub-setting" colspan="2">Starting Location</td>
+                    <td class="option" colspan="2">
+                        <select id="starting-location">
+                            <option value="Random">Random</option>
+                            <option selected value="ToadTown">Toad Town</option>
+                            <option value="GoombaVillage">Goomba Village</option>
+                            <option value="DryDryOutpost">Dry Dry Outpost</option>
+                            <option value="YoshiVillage">Yoshi Village</option>
+                        </select>
                     </td>
                 </tr>
                 <tr class="seed-setting">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -802,7 +802,7 @@ $(document).ready(function(){
         for (var i = 1; i <= 4; ++i) {
             $(`.seed-${i}`).toggle(i > 4 - requiredCount);
         }
-        getAvailableChecks("chapter-6-entry");
+        if (!isPageReloading) getAvailableChecks("chapter-6-entry");
     });
 
     $("#blue-house-open").click(function() {
@@ -823,7 +823,7 @@ $(document).ready(function(){
     });
 
     $("#starting-location").change(function() {
-        getAvailableChecks("starting-location");
+        if (!isPageReloading) getAvailableChecks("starting-location");
         localStorage.setItem("starting-location", $("#starting-location").val());
         checkIfChapterIsCompletable(2);
         checkIfChapterIsCompletable(5);
@@ -1230,7 +1230,7 @@ var isPageReloading = false;
 function resetPage() {
     isPageReloading = true;
     // clear out all single click items
-    $("img.optional-item, img.key-item, img.partner").each(function() {
+    $("img.optional-item, img.key-item, img.partner, img.koot-item").each(function() {
         if (!$(this).hasClass("unselected")) {
             $(this).addClass("unselected");
         }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -37,11 +37,12 @@ var currentKeyCounts = {
 // Any nested arrays means that if any condition from that group is true, the entire group is treated as true.
 const extraChapterRequirements = {
     1: [
+        ["#Hammer", "Super Hammer", "#Bombette"], // tree for switch on pleasant path
         "#Kooper" // switch to bring up bridge on pleasant path
     ],
     2: [
-        ["#Bombette", "Super Hammer"], // need bombette to blow up rock in toad town (or super hammer for sewers)
-        ["#Parakarry", "Super Hammer"] // this is just to access the ruins via mt rugged or sewers respectively
+        ["#starting-location [value='DryDryOutpost']", "#Bombette", "Super Hammer"], // need bombette to blow up rock in toad town (or super hammer for sewers)
+        ["#starting-location [value='DryDryOutpost']", "#Parakarry", "Super Hammer"] // this is just to access the ruins via mt rugged or sewers respectively
     ],
     3: [
         "#Parakarry", // need parakarry to get to Tubba's Castle
@@ -50,12 +51,15 @@ const extraChapterRequirements = {
     4: [
         "#Bombette", // blow up the wall to general guy
         "#Watt", // see in the room before general guy
+        ["#Hammer", "Super Hammer"], // hit boxes in green station
         ["#Bow", "#toybox-open"] // need Bow to get into toybox if it is not open by default
     ],
     5: [
         "#Sushie", // need sushie in order to place the jade raven
         ["#Parakarry", "#Lakilester"], // need one of these in order to get hammer upgrade
+        ["#Hammer", "Super Hammer"], // drop log bridge
         [
+            "#starting-location [value='YoshiVillage']",
             "#Watt", 
             "#whale-open", // watt or whale open to get to the island OR vvvv
             ["#Bombette", ["img[data-item-name='Odd Key']", "#blue-house-open"]], // bombette AND access to blue house for pipe
@@ -66,6 +70,7 @@ const extraChapterRequirements = {
     7: [
         "#Kooper", // switch on shiver mountain
         "#Bombette", // switch in crystal palace
+        ["#Hammer", "Super Hammer"], // hit fake Kooper
         "Super Boots", // break the ice on shiver mountain
         ["#Sushie", "#blue-house-open", "img[data-item-name='Odd Key']"] // access to chapter 7 via blue house or past Blooper fight
     ],
@@ -168,16 +173,16 @@ function checkIfChapterIsCompletable(chapter) {
             for (var i = 0; i < requirementsArray.length; ++i) {
                 var elem = $(requirementsArray[i]).first();
                 var isChecked = elem.is(':checkbox') && elem.is(":checked");
-                var selected = !elem.is(':checkbox') && !elem.hasClass("unselected");
+                var selected = elem.is(':selected') || elem.length && !elem.is(':checkbox') && !elem.is('option') && !elem.hasClass("unselected");
 
                 // if boots upgrade is required, increment when normal boots are not active
                 if (requirementsArray[i] === "Super Boots") {
-                    if ($("#Boots").length === 0) {
+                    if ($("[id='Super Boots']").length || $("[id='Ultra Boots']").length) {
                         ++conditionsComplete;
                     }
                 // if hammer upgrade is required, mark completed if the hammer is not default
                 } else if (requirementsArray[i] === "Super Hammer") {
-                    if ($("#Hammer").length === 0) {
+                    if ($("[id='Super Hammer']").length || $("[id='Ultra Hammer']").length) {
                         ++conditionsComplete;
                     }
                 } else if (Array.isArray(requirementsArray[i])) {
@@ -199,11 +204,11 @@ function checkIfChapterIsCompletable(chapter) {
 
         for (var i = 0; i < extraChapterRequirements[chapter].length; ++i) {
             if (extraChapterRequirements[chapter][i] === "Super Boots") {
-                if ($("#Boots").length === 0) {
+                if ($("[id='Super Boots']").length || $("[id='Ultra Boots']").length) {
                     ++completedCount;
                 }
             } else if (extraChapterRequirements[chapter][i] === "Super Hammer") {
-                if ($("#Hammer").length === 0) {
+                if ($("[id='Super Hammer']").length || $("[id='Ultra Hammer']").length) {
                     ++completedCount;
                 }
             // if a condition is an array, the condition is true if any element of the array is true
@@ -415,7 +420,7 @@ function initializePage() {
         }
 
         if (!isPageReloading) {
-            getAvailableChecks($(this).attr('id').split(' ').at(-1));
+            getAvailableChecks($(this).attr('id').split(' ').at(-1).split('-').at(0));
         }
     });
 
@@ -674,6 +679,10 @@ $(document).ready(function(){
                     if (data["BlueHouseOpen"] != $("#blue-house-open").is(':checked')) {
                         $("#blue-house-open").click();
                     }
+
+                    if (data["StartingMap"] != $("#starting-location").val()) {
+                        $("#starting-location").val(data["StartingMap"]);
+                    }
                     
                     if ((data["BowsersCastleMode"] >= 1) != $("#fast-bowser-castle").is(':checked')) {
                         $("#fast-bowser-castle").click();
@@ -811,6 +820,13 @@ $(document).ready(function(){
         localStorage.setItem("blue-house-open", isChecked);
         checkIfChapterIsCompletable(5);
         checkIfChapterIsCompletable(7);
+    });
+
+    $("#starting-location").change(function() {
+        getAvailableChecks("starting-location");
+        localStorage.setItem("starting-location", $("#starting-location").val());
+        checkIfChapterIsCompletable(2);
+        checkIfChapterIsCompletable(5);
     });
 
     $("#fast-bowser-castle").click(function() {
@@ -1009,6 +1025,10 @@ $(document).ready(function(){
     if (blue_house_open) {
         $("#blue-house-open").click();
     }
+
+    var starting_location = localStorageGetWithDefault("starting-location", "ToadTown");
+    $("#starting-location").val(starting_location);
+    $("#starting-location").change();
 
     var fast_bowser_castle = localStorageGetWithDefault("fast-bowser-castle", false) == "true";
     if (fast_bowser_castle) {
@@ -1276,6 +1296,7 @@ function resetPage() {
     $("#trading-event-randomized").click();
     $("#trading-event-randomized").click();
     $("#seeds-required").change();
+    $("#starting-location").change();
     isPageReloading = false;
     getAvailableChecks();
 }

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -184,6 +184,8 @@ function resetMapChecks() {
 
     $("td[data-checks-list]").removeClass("complete");
     $("button.map-select").removeClass("complete");
+    $("td[data-checks-list]").removeClass("unavailable");
+    $("button.map-select").removeClass("unavailable");
 }
 
 // this function needs to be called after initializeMaps as it will rebind new events for some checks

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -274,6 +274,8 @@ function getAvailableChecks(check) {
                         for (var subsubreq of subreq) {
                             if (typeof(subsubreq) == typeof(1)) {
                                 available = $('.star-spirit:not(.unselected)').length >= subsubreq;
+                            } else if (typeof(subsubreq) == typeof('') && subsubreq.startsWith("starting-location:")) {
+                                available = subsubreq.includes($("#starting-location").val());
                             } else if (typeof(subsubreq) == typeof('')) {
                                 available = $("[id=\"" + subsubreq + "\"]").length && $("[id=\"" + subsubreq + "\"]:not(.unselected)").length && ($("input[id=\"" + subsubreq + "\"]:checked").length || !$("input[id=\"" + subsubreq + "\"]").length);
                             } else {
@@ -283,6 +285,8 @@ function getAvailableChecks(check) {
                         }
                     } else if (typeof(subreq) == typeof(1)) {
                         available = $('.star-spirit:not(.unselected)').length >= subreq;
+                    } else if (typeof(subreq) == typeof('') && subreq.startsWith("starting-location:")) {
+                        available = subreq.includes($("#starting-location").val());
                     } else if (typeof(subreq) == typeof('')) {
                         available = $("[id=\"" + subreq + "\"]").length && $("[id=\"" + subreq + "\"]:not(.unselected)").length && ($("input[id=\"" + subreq + "\"]:checked").length || !$("input[id=\"" + subreq + "\"]").length);
                     } else {
@@ -302,6 +306,8 @@ function getAvailableChecks(check) {
                     available = false;
                     break;
                 }
+            } else if (typeof(req) == typeof('') && req.startsWith("starting-location:")) {
+                available = req.includes($("#starting-location").val());
             } else if (typeof(req) == typeof('')) {
                 available = $("[id=\"" + req + "\"]").length && $("[id=\"" + req + "\"]:not(.unselected)").length && ($("input[id=\"" + req + "\"]:checked").length || !$("input[id=\"" + req + "\"]").length);
             } else {


### PR DESCRIPTION
- Updated both the Star Spirit completion logic and map logic to account for starting location (#14, #49)
- Updated both the Star Spirit completion logic and map logic to account for a potential hammerless start (#62)
- Fixed an issue where certain tracker elements were not reset properly (#57)

Known issues
-
- Big Chest Shuffle is not yet accounted for
- Additional logic requirements for hammerless start may impact performance negatively when selecting/unselecting hammer upgrades and Bombette (related to #51)