### PR TITLE
Fix for Misstar selection not marking chest in chapter 5 as accessible

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -618,6 +618,7 @@ function initializePage() {
         checkIfChapterIsCompletable(8);
         updateKoopaKootAvailable();
         if (!isPageReloading) {
+            getAvailableChecks($(this).attr('id'));
             getAvailableChecks($('.star-spirit:not(.unselected)').length);
         }
     });


### PR DESCRIPTION
There's probably a better way to fix this tbh, but this was just a straight forward "fix it now" patch. It's already in live, PR mostly just to bring attention to it.