### PR TITLE
Allow marking off all checks by right-clicking a map section

### DIFF
--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -173,6 +173,15 @@ function initializeMaps() {
     $("#map-checks input").click(function() {
         updateSingleMapCheck($(this));
     });
+
+    // marks off all checks for a given map on right-click
+    $("table.map td").contextmenu(function(e) {
+        $(`#${$(this).attr("data-checks-list")} input`).each(function() {
+            if ($(this).not(':checked')) {
+                $(this).click();
+            }
+        });
+    });
 }
 
 function resetMapChecks() {


### PR DESCRIPTION
This PR adds the ability to right click a map section and mark off all checks in that section, using a similar method of how the reset feature works.