### PR TITLE
Fixing some issues with right-clicking areas

### DIFF
--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -182,7 +182,7 @@ function initializeMaps() {
 
     // marks off all checks for a given map on right-click
     $("table.map td").contextmenu(function(e) {
-        $(`#${$(this).attr("data-checks-list")} input`).each(function() {
+        $(`#${$(this).attr("data-checks-list")} input:not(:disabled)`).each(function() {
             if ($(this).not(':checked')) {
                 $(this).click();
             }

--- a/scripts/maps.js
+++ b/scripts/maps.js
@@ -182,10 +182,8 @@ function initializeMaps() {
 
     // marks off all checks for a given map on right-click
     $("table.map td").contextmenu(function(e) {
-        $(`#${$(this).attr("data-checks-list")} input:not(:disabled)`).each(function() {
-            if ($(this).not(':checked')) {
-                $(this).click();
-            }
+        $(`#${$(this).attr("data-checks-list")} input:not(:disabled):not(:checked)`).each(function() {
+            $(this).click();
         });
     });
 }


### PR DESCRIPTION
Currently when right-clicking an area with disabled checks the check counters for total/panels/coinsanity can become negative due to forcing the .click() function on them.

There is also an issue with the logic that checks whether or not an input is checked which causes the right click to just toggle every input. This can cause already checked inputs to become unchecked.

These changes add a `:not(:disabled)` to the jQuery check as well as moves the `.not(':checked')` into the original jQuery check since we want to see if the resulting input is checked and checking in the jQuery or outside if functionally the same.

I replicated the issue originally on Firefox 107.0 and Chrome 104.0.5112.81