### PR TITLE
Fix foliage coin in southeast desert

### DIFF
--- a/index.html
+++ b/index.html
@@ -1583,7 +1583,7 @@
                         <div id="maps-desert-multicoin-blocks" style="display:none;">
                             <h3>Six Multicoin Blocks</h3>
                             <ul>
-                                <li><label><input data-map-group="maps-desert-northeast" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">[Foliage Coin] Far right tree</label></li>
+                                <li><label><input data-map-group="maps-desert-multicoin-blocks" autocomplete="off" type="checkbox" data-requirements-glitchless="['starting-location:DryDryOutpost',['Bombette','Parakarry'],'Super Hammer','Ultra Hammer'],['Hammer','Super Hammer','Ultra Hammer','Bombette']">[Foliage Coin] Far right tree</label></li>
                             </ul>
                         </div>
                         <!--------------------------------------------------------------


### PR DESCRIPTION
Fix the map group of the foliage coin in maps-desert-multicoin-blocks; was maps-desert-northeast