### PR TITLE
Fix Bowser Castle Keys not showing up on Required Tracker with Power Star Hunt

### DIFF
--- a/src/components/RequiredTracker.vue
+++ b/src/components/RequiredTracker.vue
@@ -2,13 +2,11 @@
 import { ref, computed } from "vue";
 import TrackableItem from "./TrackableItem.vue";
 import { usePlaythrough } from "../stores/playthrough";
-import { useOptions } from "@/stores/config";
 import ItemTracker from "./ItemTracker.vue";
 import type { TrackableItemInfo } from "../types/items";
 
 const tooltip = ref("");
 const playthrough = usePlaythrough();
-const options = useOptions();
 
 const props = defineProps<{
 	allItems: TrackableItemInfo[];
@@ -21,14 +19,6 @@ const requiredItems = computed(() =>
 		["chapterReward", "partner", "equipment", "required"].includes(el.type)
 	)
 );
-
-const chapterRows = computed(() => {
-	if (options.getValue("powerStarHunt")) {
-		return [1, 2, 3, 4, 5, 6, 7, 16, 0, -1];
-	} else {
-		return [1, 2, 3, 4, 5, 6, 7, 8, 0, -1];
-	}
-});
 
 function equipmentTooltip(item: string) {
 	if (item === "Boots" || item === "Hammer") {
@@ -56,7 +46,11 @@ function equipmentTooltip(item: string) {
 	>
 		<div class="container">
 			<div class="rows">
-				<div v-for="chapter in chapterRows" :key="chapter" class="gridrow">
+				<div
+					v-for="chapter in [1, 2, 3, 4, 5, 6, 7, 8, 0, -1]"
+					:key="chapter"
+					class="gridrow"
+				>
 					<TrackableItem
 						v-for="(item, index) in requiredItems.filter(
 							el => el.chapter === chapter

--- a/src/components/SeedImport.vue
+++ b/src/components/SeedImport.vue
@@ -46,7 +46,10 @@ function setRandomizerSettingsFromApiResponse(data: SettingsApiData) {
 	optionsStore.setValue("prologueOpen", data.PrologueOpen);
 	optionsStore.setValue("rowfRandomized", data.ProgressionOnRowf);
 	optionsStore.setValue("sSkip", data.StarHuntEndsGame);
-	optionsStore.setValue("seedsRequired", data.MagicalSeedsRequired);
+	optionsStore.setValue(
+		"seedsRequired",
+		Math.min(4, data.MagicalSeedsRequired)
+	);
 	optionsStore.setValue("shiverBridgeVisible", data.Ch7BridgeVisible);
 	optionsStore.setValue("shopsRandomized", data.IncludeShops);
 	optionsStore.setValue(

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -47,17 +47,17 @@ export const allItems: TrackableItemInfo[] = [
 	},
 	{
 		chapter: 8,
-		name: "Star Rod",
-		type: "chapterReward",
-		image: "icons/PM_Starrod.png",
-		show: (settings: Options) => !logic.powerStarHunt(settings),
-	},
-	{
-		chapter: 16,
 		name: "Power Stars Found",
 		type: "chapterReward",
 		image: "icons/Power_Star.png",
 		show: logic.powerStarHunt,
+	},
+	{
+		chapter: 8,
+		name: "Star Rod",
+		type: "chapterReward",
+		image: "icons/PM_Starrod.png",
+		show: (settings: Options) => !logic.powerStarHunt(settings),
 	},
 	{
 		chapter: -1,


### PR DESCRIPTION
Fixes #93. Internally this adds the Power Star item to the Chapter 8 row instead of making a new row just for the Power Stars which castle keys weren't a part of. Works the same wrt UX since the Star Rod is shown by default only if Power Star Hunt is off and Power Stars only if it's on. 

Also fixes #95 by adding a max of 4 Magical Seeds required on import. When the setting is "Random" this number is set to 5 so just clamping it to a max of 4 works fine.